### PR TITLE
Remove CodeMapper.maxcode.

### DIFF
--- a/lib/Dnsruby/code_mapper.rb
+++ b/lib/Dnsruby/code_mapper.rb
@@ -50,10 +50,6 @@ module Dnsruby
       return strings
     end
     
-    def CodeMapper.maxcode
-      return @maxcode
-    end
-    
     # Creates the CodeMapper from the defined constants
     def CodeMapper.update
 


### PR DESCRIPTION
Removed CodeMapper maxcode method.  It was always returning nil and could not have been used.
