### PR TITLE
Add rake as development dependency to gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,13 @@
 PATH
   remote: .
   specs:
-    dnsruby (1.55)
+    dnsruby (1.56.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     minitest (5.4.2)
+    rake (10.3.2)
 
 PLATFORMS
   ruby
@@ -14,3 +15,4 @@ PLATFORMS
 DEPENDENCIES
   dnsruby!
   minitest (~> 5.4)
+  rake (~> 10.1)

--- a/dnsruby.gemspec
+++ b/dnsruby.gemspec
@@ -26,5 +26,6 @@ SPEC = Gem::Specification.new do |s|
   s.extra_rdoc_files = ["DNSSEC", "EXAMPLES", "README", "EVENTMACHINE"]
 
   s.add_development_dependency 'minitest', '~> 5.4'
+  s.add_development_dependency 'rake',     '~> 10.1'
 end
 


### PR DESCRIPTION
Without rake as a development dependency,  bundle exec rake test does not work in Ruby 2.1.
