### PR TITLE
 Make message.to_s output more dig-like. Add tc_message.rb and refer to ...

### DIFF
--- a/lib/Dnsruby/message.rb
+++ b/lib/Dnsruby/message.rb
@@ -13,8 +13,10 @@
 #See the License for the specific language governing permissions and 
 #limitations under the License.
 #++
-require 'Dnsruby/name'
-require 'Dnsruby/resource/resource'
+
+require 'dnsruby/name'
+require 'dnsruby/resource/resource'
+
 module Dnsruby
   #===Defines a DNS packet.
   # 
@@ -94,7 +96,7 @@ module Dnsruby
       end
       # Return the rrset of the specified type in this section
       def rrset(name, type=Types.A, klass=Classes::IN)
-        rrs = select{|rr| 
+        rrs = select{|rr|
           type_ok = (rr.type==type)
           if (rr.type == Types::RRSIG)
             type_ok = (rr.type_covered == type)
@@ -110,7 +112,7 @@ module Dnsruby
         end
         return rrset
       end
-      
+
       # Return an array of all the rrsets in the section
       def rrsets(type = nil, include_opt = false)
         if (type && !(Types === type))
@@ -147,7 +149,7 @@ module Dnsruby
             ret.push(RRSet.new(rr))
           end
         end
-        return ret        
+        return ret
       end
       def ==(other)
         return false unless (other.instance_of?Message::Section)
@@ -217,10 +219,10 @@ module Dnsruby
         add_question(name, type, klass)
       end
     end
-    
+
     #The question section, an array of Dnsruby::Question objects.
     attr_reader :question
-    
+
     #The answer section, an array of Dnsruby::RR objects.
     attr_reader :answer
     #The authority section, an array of Dnsruby::RR objects.
@@ -229,20 +231,20 @@ module Dnsruby
     attr_reader :additional
     #The header section, a Dnsruby::Header object.
     attr_accessor :header
-    
+
     #If this Message is a response from a server, then answerfrom contains the address of the server
     attr_accessor :answerfrom
-    
+
     #If this Message is a response from a server, then answerfrom contains the IP address of the server
     attr_accessor :answerip
-    
+
     #If this Message is a response from a server, then answersize contains the size of the response
     attr_accessor :answersize
-    
+
     #If this message has been verified using a TSIG RR then tsigerror contains
     #the error code returned by the TSIG verification. The error will be an RCode
     attr_accessor :tsigerror
-    
+
     #Can be
     #* :Unsigned - the default state
     #* :Signed - the outgoing message has been signed
@@ -251,11 +253,11 @@ module Dnsruby
     #in which only every 100th envelope must be signed
     #* :Failed - the incoming response failed verification
     attr_accessor :tsigstate
-    
+
     #--
     attr_accessor :tsigstart
     #++
-    
+
     #Set send_raw if you wish to send and receive the response to this Message
     #with no additional processing. In other words, if set, then Dnsruby will
     #not touch the Header of the outgoing Message. This option does not affect
@@ -306,10 +308,10 @@ module Dnsruby
       ret = false
       if (other.kind_of?Message)
         ret = @header == other.header &&
-          @question[0] == other.question[0] &&
-          @answer == other.answer &&
-          @authority == other.authority &&
-          @additional == other.additional
+            @question[0] == other.question[0] &&
+            @answer == other.answer &&
+            @authority == other.authority &&
+            @additional == other.additional
       end
       return ret
     end
@@ -328,7 +330,7 @@ module Dnsruby
       end
       return RRSet.new
     end
-    
+
     # Return the rrsets of the specified type in the message
     def rrsets(type, klass=Classes::IN)
       rrsetss = []
@@ -341,7 +343,7 @@ module Dnsruby
       end
       return rrsetss
     end
-    
+
     # Return a hash, with the section as key, and the RRSets in that
     # section as the data : {section => section_rrs}
     def section_rrsets(type = nil, include_opt = false)
@@ -351,7 +353,7 @@ module Dnsruby
       end
       return ret
     end
-    
+
     #Add a new Question to the Message. Takes either a Question,
     #or a name, and an optional type and class.
     #
@@ -365,7 +367,7 @@ module Dnsruby
       @question << question
       update_counts
     end
-    
+
     def each_question
       @question.each {|rec|
         yield rec
@@ -378,52 +380,52 @@ module Dnsruby
       @header.qdcount = @question.length
       @header.nscount = @authority.length
     end
-    
-    
+
+
     def add_answer(rr) #:nodoc: all
       if (!@answer.include?rr)
         @answer << rr
         update_counts
       end
     end
-    
+
     def each_answer
       @answer.each {|rec|
         yield rec
       }
     end
-    
+
     def add_authority(rr) #:nodoc: all
       if (!@authority.include?rr)
         @authority << rr
         update_counts
       end
     end
-    
+
     def each_authority
       @authority.each {|rec|
         yield rec
       }
     end
-    
+
     def add_additional(rr) #:nodoc: all
       if (!@additional.include?rr)
         @additional << rr
         update_counts
       end
     end
-    
+
     def each_additional
       @additional.each {|rec|
         yield rec
       }
     end
-    
+
     #Yields each section (question, answer, authority, additional)
     def each_section
       [@answer, @authority, @additional].each {|section| yield section}
     end
-    
+
     #Calls each_answer, each_authority, each_additional
     def each_resource
       each_answer {|rec| yield rec}
@@ -440,7 +442,7 @@ module Dnsruby
       end
       return nil
     end
-    
+
     #Sets the TSIG to sign this message with. Can either be a Dnsruby::RR::TSIG
     #object, or it can be a (name, key) tuple, or it can be a hash which takes
     #Dnsruby::RR::TSIG attributes (e.g. name, key, fudge, etc.)
@@ -459,19 +461,19 @@ module Dnsruby
         raise ArgumentError.new("Wrong number of arguments to Dnsruby::Message#set_tsig")
       end
     end
-    
+
     #Was this message signed by a TSIG?
     def signed?
       return (@tsigstate == :Signed ||
           @tsigstate == :Verified ||
           @tsigstate == :Failed)
     end
-    
+
     #If this message was signed by a TSIG, was the TSIG verified?
     def verified?
       return (@tsigstate == :Verified)
     end
-    
+
     def get_opt
       each_additional do |r|
         if (r.type == Types::OPT)
@@ -480,7 +482,7 @@ module Dnsruby
       end
       return nil
     end
-    
+
     def rcode
       rcode = @header.get_header_rcode
       opt = get_opt
@@ -492,34 +494,83 @@ module Dnsruby
     end
 
     def to_s
+      s = ''  # the output string to return
+
+      if @answerfrom && (! @answerfrom.empty?)
+        s << ";; Answer received from #{@answerfrom} (#{@answersize} bytes)\n;;\n"
+      end
+
+      s << ";; Security Level : #{@security_level.string}\n"
+
+      # OPT pseudosection? EDNS flags, udpsize
+      opt = get_opt
+
+      if opt
+        s << @header.to_s_with_rcode(rcode) << "\n#{opt}\n"
+      else
+        s << "#{@header}\n"
+      end
+
+      section = (@header.opcode == OpCode.UPDATE) ? "ZONE" : "QUESTION"
+      s <<  ";; #{section} SECTION (#{@header.qdcount}  record#{@header.qdcount == 1 ? '' : 's'})\n"
+      each_question { |qr| s << ";; #{qr}\n" }
+
+      if @answer.size > 0
+        s << "\n"
+        section = (@header.opcode == OpCode.UPDATE) ? "PREREQUISITE" : "ANSWER"
+        s << ";; #{section} SECTION (#{@header.ancount}  record#{@header.ancount == 1 ? '' : 's'})\n"
+        each_answer { |rr| s << "#{rr}\n" }
+      end
+
+      if @authority.size > 0
+        s << "\n"
+        section = (@header.opcode == OpCode.UPDATE) ? "UPDATE" : "AUTHORITY"
+        s << ";; #{section} SECTION (#{@header.nscount}  record#{@header.nscount == 1 ? '' : 's'})\n"
+        each_authority { |rr| s << rr.to_s + "\n" }
+      end
+
+      if (@additional.size > 0 && !opt) || (@additional.size > 1)
+        s << "\n;; ADDITIONAL SECTION (#{@header.arcount}  record#{@header.arcount == 1 ? '' : 's'})\n"
+        each_additional { |rr|
+          if rr.type != Types::OPT
+            s << rr.to_s+ "\n"
+          end
+        }
+      end
+
+      s
+    end
+
+
+    def old_to_s
       retval = "";
-      
+
       if (@answerfrom != nil && @answerfrom != "")
         retval = retval + ";; Answer received from #{@answerfrom} (#{@answersize} bytes)\n;;\n";
       end
       retval = retval + ";; Security Level : #{@security_level.string}\n"
-      
+
       retval = retval + ";; HEADER SECTION\n"
       # OPT pseudosection? EDNS flags, udpsize
       opt = get_opt
       if (!opt)
-        retval = retval + @header.to_s
+        retval = retval + @header.old_to_s
       else
-        retval = retval + @header.to_s_with_rcode(rcode())
+        retval = retval + @header.old_to_s_with_rcode(rcode())
       end
       retval = retval + "\n"
-      
+
       if (opt)
         retval = retval + opt.to_s
         retval = retval + "\n"
       end
-            
+
       section = (@header.opcode == OpCode.UPDATE) ? "ZONE" : "QUESTION";
       retval = retval +  ";; #{section} SECTION (#{@header.qdcount}  record#{@header.qdcount == 1 ? '' : 's'})\n";
       each_question { |qr|
         retval = retval + ";; #{qr.to_s}\n";
       }
-      
+
       if (@answer.size > 0)
         retval = retval + "\n";
         section = (@header.opcode == OpCode.UPDATE) ? "PREREQUISITE" : "ANSWER";
@@ -528,7 +579,7 @@ module Dnsruby
           retval = retval + rr.to_s + "\n";
         }
       end
-      
+
       if (@authority.size > 0)
         retval = retval + "\n";
         section = (@header.opcode == OpCode.UPDATE) ? "UPDATE" : "AUTHORITY";
@@ -537,7 +588,7 @@ module Dnsruby
           retval = retval + rr.to_s + "\n";
         }
       end
-      
+
       if ((@additional.size > 0 && !opt) || (@additional.size > 1))
         retval = retval + "\n";
         retval = retval + ";; ADDITIONAL SECTION (#{@header.arcount}  record#{@header.arcount == 1 ? '' : 's'})\n";
@@ -547,10 +598,10 @@ module Dnsruby
           end
         }
       end
-      
+
       return retval;
     end
-    
+
     #Signs the message. If used with no arguments, then the message must have already
     #been set (set_tsig). Otherwise, the arguments can either be a Dnsruby::RR::TSIG
     #object, or a (name, key) tuple, or a hash which takes
@@ -568,7 +619,7 @@ module Dnsruby
         end
       end
     end
-    
+
     #Return the encoded form of the message
     # If there is a TSIG record present and the record has not been signed
     # then sign it
@@ -592,7 +643,7 @@ module Dnsruby
         }
       }.to_s
     end
-    
+
     #Decode the encoded message
     def Message.decode(m)
       o = Message.new()
@@ -664,46 +715,46 @@ module Dnsruby
     alias :update :authority
     alias :add_update :add_authority
     alias :each_update :each_authority
-    
+
   end
-  
+
   #The header portion of a DNS packet
   #
   #RFC 1035 Section 4.1.1
   class Header
     MAX_ID = 65535
-    
+
     # The header ID
     attr_accessor :id
-    
+
     #The query response flag
     attr_accessor :qr
-    
+
     #Authoritative answer flag
     attr_accessor :aa
-    
+
     #Truncated flag
     attr_accessor :tc
-    
+
     #Recursion Desired flag
     attr_accessor :rd
-    
+
     #The Checking Disabled flag
     attr_accessor :cd
-    
+
     #The Authenticated Data flag
     #Relevant in DNSSEC context.
     #(The AD bit is only set on answers where signatures have been
     #cryptographically verified or the server is authoritative for the data
     #and is allowed to set the bit by policy.)
     attr_accessor :ad
-    
+
     #The query response flag
     attr_accessor :qr
-    
+
     #Recursion available flag
     attr_accessor :ra
-    
+
     #Query response code
     #deprecated - use Message#rcode
     #    attr_reader :rcode
@@ -715,10 +766,10 @@ module Dnsruby
     def get_header_rcode
       @rcode
     end
-    
+
     # The header opcode
     attr_reader :opcode
-    
+
     #The number of records in the question section of the message
     attr_accessor :qdcount
     #The number of records in the authoriy section of the message
@@ -727,7 +778,7 @@ module Dnsruby
     attr_accessor :ancount
     #The number of records in the additional record section og the message
     attr_accessor :arcount
-    
+
     def initialize(*args)
       if (args.length == 0)
         @id = rand(MAX_ID)
@@ -748,46 +799,46 @@ module Dnsruby
         decode(args[0])
       end
     end
-    
+
     def opcode=(op)
       @opcode = OpCode.new(op)
     end
-    
+
     def rcode=(rcode)
       @rcode = RCode.new(rcode)
     end
-    
+
     def Header.new_from_data(data)
       header = Header.new
       MessageDecoder.new(data) {|msg|
         header.decode(msg)}
       return header
     end
-    
+
     def data
       return MessageEncoder.new {|msg|
         self.encode(msg)
       }.to_s
     end
-    
+
     def encode(msg)
       msg.put_pack('nnnnnn',
-        @id,
-        (@qr ? 1:0) << 15 |
-        (@opcode.code & 15) << 11 |
-        (@aa ? 1:0) << 10 |
-        (@tc ? 1:0) << 9 |
-        (@rd ? 1:0) << 8 |
-        (@ra ? 1:0) << 7 |
-        (@ad ? 1:0) << 5 |
-        (@cd ? 1:0) << 4 |
-        (@rcode.code & 15),
-        @qdcount,
-        @ancount,
-        @nscount,
-        @arcount)
+          @id,
+          (@qr ? 1:0) << 15 |
+             (@opcode.code & 15) << 11 |
+             (@aa ? 1:0) << 10 |
+             (@tc ? 1:0) << 9 |
+             (@rd ? 1:0) << 8 |
+             (@ra ? 1:0) << 7 |
+             (@ad ? 1:0) << 5 |
+             (@cd ? 1:0) << 4 |
+             (@rcode.code & 15),
+          @qdcount,
+          @ancount,
+          @nscount,
+          @arcount)
     end
-    
+
     def Header.decrement_arcount_encoded(bytes)
       header = Header.new
       header_end = 0
@@ -800,31 +851,73 @@ module Dnsruby
         header.encode(msg)}.to_s
       return bytes
     end
-    
+
     def ==(other)
       return @qr == other.qr &&
-        @opcode == other.opcode &&
-        @aa == other.aa &&
-        @tc == other.tc &&
-        @rd == other.rd &&
-        @ra == other.ra &&
-        @cd == other.cd &&
-        @ad == other.ad &&
-        @rcode == other.get_header_rcode
+          @opcode == other.opcode &&
+          @aa == other.aa &&
+          @tc == other.tc &&
+          @rd == other.rd &&
+          @ra == other.ra &&
+          @cd == other.cd &&
+          @ad == other.ad &&
+          @rcode == other.get_header_rcode
     end
-    
+
     def to_s
       to_s_with_rcode(@rcode)
     end
-      
+
+    def old_to_s
+      old_to_s_with_rcode(@rcode)
+    end
+
     def to_s_with_rcode(rcode)
+
+      if (@opcode == OpCode::Update)
+        s = ";; id = #{@id}\n"
+        s << ";; qr = #{@qr}    opcode = #{@opcode.string}    rcode = #{@rcode.string}\n"
+        s << ";; zocount = #{@qdcount}  "
+        s <<  "prcount = #{@ancount}  "
+        s <<  "upcount = #{@nscount}  "
+        s <<  "adcount = #{@arcount}\n"
+        s
+      else
+
+        flags_str = -> do
+          flags = []
+          flags << 'qr' if @qr
+          flags << 'aa' if @aa
+          flags << 'tc' if @tc
+          flags << 'rd' if @rd
+          flags << 'ra' if @ra
+          flags << 'ad' if @ad
+          flags << 'cd' if @cd
+
+          ";; flags: #{flags.join(' ')}; "
+        end
+
+        head_line_str = -> do
+          ";; ->>HEADER<<- opcode: #{opcode.string.upcase}, status: #{@rcode.string}, id: #{@id}\n"
+        end
+
+        section_counts_str = -> do
+          "QUERY: #{@qdcount}, ANSWER: #{@ancount}, AUTHORITY: #{@nscount}, ADDITIONAL: #{@arcount}\n"
+        end
+
+        head_line_str.() + flags_str.() + section_counts_str.()
+      end
+    end
+
+
+    def old_to_s_with_rcode(rcode)
       retval = ";; id = #{@id}\n";
-      
+
       if (@opcode == OpCode::Update)
         retval += ";; qr = #{@qr}    " +\
           "opcode = #{@opcode.string}    "+\
           "rcode = #{@rcode.string}\n";
-        
+
         retval += ";; zocount = #{@qdcount}  "+\
           "prcount = #{@ancount}  " +\
           "upcount = #{@nscount}  "  +\
@@ -835,24 +928,24 @@ module Dnsruby
           "aa = #{@aa}    "  +\
           "tc = #{@tc}    " +\
           "rd = #{@rd}\n";
-        
+
         retval += ";; ra = #{@ra}    " +\
           "ad = #{@ad}    "  +\
           "cd = #{@cd}    "  +\
           "rcode  = #{rcode.string}\n";
-        
+
         retval += ";; qdcount = #{@qdcount}  " +\
           "ancount = #{@ancount}  " +\
           "nscount = #{@nscount}  " +\
           "arcount = #{@arcount}\n";
       end
-      
+
       return retval;
     end
-    
+
     def decode(msg)
       @id, flag, @qdcount, @ancount, @nscount, @arcount =
-        msg.get_unpack('nnnnnn')
+          msg.get_unpack('nnnnnn')
       @qr = (((flag >> 15)&1)==1)?true:false
       @opcode = OpCode.new((flag >> 11) & 15)
       @aa = (((flag >> 10)&1)==1)?true:false
@@ -863,21 +956,21 @@ module Dnsruby
       @cd = (((flag >> 4)&1)==1)?true:false
       @rcode = RCode.new(flag & 15)
     end
-    
+
     alias zocount qdcount
     alias zocount= qdcount=
-    
+
     alias prcount ancount
     alias prcount= ancount=
-    
+
     alias upcount nscount
     alias upcount= nscount=
-    
+
     alias adcount arcount
     alias adcount= arcount=
-    
+
   end
-  
+
   class MessageDecoder #:nodoc: all
     attr_reader :index
     def initialize(data)
@@ -886,11 +979,11 @@ module Dnsruby
       @limit = data.length
       yield self
     end
-    
+
     def has_remaining
       return @limit-@index > 0
     end
-    
+
     def get_length16
       len, = self.get_unpack('n')
       save_limit = @limit
@@ -904,13 +997,13 @@ module Dnsruby
       @limit = save_limit
       return d
     end
-    
+
     def get_bytes(len = @limit - @index)
       d = @data[@index, len]
       @index += len
       return d
     end
-    
+
     def get_unpack(template)
       len = 0
       littlec = ?c
@@ -932,18 +1025,18 @@ module Dnsruby
       end
       template.each_byte {|byte|
         case byte
-        when littlec, bigc
-          len += 1
-        when littleh, bigh
-          len += 1
-        when littlen
-          len += 2
-        when bign
-          len += 4
-        when star
-          len = @limit-@index
-        else
-          raise StandardError.new("unsupported template: '#{byte.chr}' in '#{template}'")
+          when littlec, bigc
+            len += 1
+          when littleh, bigh
+            len += 1
+          when littlen
+            len += 2
+          when bign
+            len += 4
+          when star
+            len = @limit-@index
+          else
+            raise StandardError.new("unsupported template: '#{byte.chr}' in '#{template}'")
         end
       }
       raise DecodeError.new("limit exceeded") if @limit < @index + len
@@ -951,7 +1044,7 @@ module Dnsruby
       @index += len
       return arr
     end
-    
+
     def get_string
       len = @data[@index]
       if (len.class == String)
@@ -962,7 +1055,7 @@ module Dnsruby
       @index += 1 + len
       return d
     end
-    
+
     def get_string_list
       strings = []
       while @index < @limit
@@ -970,11 +1063,11 @@ module Dnsruby
       end
       strings
     end
-    
+
     def get_name
       return Name.new(self.get_labels)
     end
-    
+
     def get_labels(limit=nil)
       limit = @index if !limit || @index < limit
       d = []
@@ -984,44 +1077,44 @@ module Dnsruby
           temp = (temp.getbyte(0))
         end
         case temp # @data[@index]
-        when 0
-          @index += 1
-          return d
-        when 192..255
-          idx = self.get_unpack('n')[0] & 0x3fff
-          if limit <= idx
-            raise DecodeError.new("non-backward name pointer")
-          end
-          save_index = @index
-          @index = idx
-          d += self.get_labels(limit)
-          @index = save_index
-          return d
-        else
-          d << self.get_label
+          when 0
+            @index += 1
+            return d
+          when 192..255
+            idx = self.get_unpack('n')[0] & 0x3fff
+            if limit <= idx
+              raise DecodeError.new("non-backward name pointer")
+            end
+            save_index = @index
+            @index = idx
+            d += self.get_labels(limit)
+            @index = save_index
+            return d
+          else
+            d << self.get_label
         end
       end
       return d
     end
-    
+
     def get_label
       begin
         #        label = Name::Label.new(Name::decode(self.get_string))
         label = Name::Label.new(self.get_string)
         return label
-        #         return Name::Label::Str.new(self.get_string)
+          #         return Name::Label::Str.new(self.get_string)
       rescue ResolvError => e
         raise DecodeError.new(e) # Turn it into something more suitable
       end
     end
-    
+
     def get_question
       name = self.get_name
       type, klass = self.get_unpack("nn")
       q = Question.new(name, type, klass)
       return q
     end
-    
+
     def get_rr
       name = self.get_name
       type, klass, ttl = self.get_unpack('nnN')
@@ -1037,26 +1130,26 @@ module Dnsruby
       return rec
     end
   end
-  
+
   class MessageEncoder #:nodoc: all
     def initialize
       @data = ''
       @names = {}
       yield self
     end
-    
+
     def to_s
       return @data
     end
-    
+
     def put_bytes(d)
       @data << d
     end
-    
+
     def put_pack(template, *d)
       @data << d.pack(template)
     end
-    
+
     def put_length16
       length_index = @data.length
       @data << "\0\0"
@@ -1065,18 +1158,18 @@ module Dnsruby
       data_end = @data.length
       @data[length_index, 2] = [data_end - data_start].pack("n")
     end
-    
+
     def put_string(d)
       self.put_pack("C", d.length)
       @data << d
     end
-    
+
     def put_string_list(ds)
       ds.each {|d|
         self.put_string(d)
       }
     end
-    
+
     def put_rr(rr, canonical=false)
       # RFC4034 Section 6.2
       put_name(rr.name, canonical)
@@ -1092,7 +1185,7 @@ module Dnsruby
       end
       put_labels(d.to_a, canonical)
     end
-    
+
     def put_labels(d, do_canonical)
       d.each_index {|i|
         domain = d[i..-1].join(".")
@@ -1106,8 +1199,8 @@ module Dnsruby
       }
       @data << "\0"
     end
-    
-    
+
+
     def put_label(d)
       #      s, = Name.encode(d)
       s = d
@@ -1115,7 +1208,7 @@ module Dnsruby
       self.put_string(s.string)
     end
   end
-  
+
   #A Dnsruby::Question object represents a record in the
   #question section of a DNS packet.
   #
@@ -1127,7 +1220,7 @@ module Dnsruby
     attr_reader :qtype
     # The Question class
     attr_reader :qclass
-    
+
     #Creates a question object from the domain, type, and class passed
     #as arguments.
     #
@@ -1154,11 +1247,54 @@ module Dnsruby
       @qname=args[0]
       if (!type_given)
         case @qname.to_s
+          when IPv4::Regex
+            @qname = IPv4.create(@qname).to_name
+            @qtype = Types.PTR
+          when IPv6::Regex
+            @qname = IPv6.create(@qname).to_name
+            @qtype = Types.PTR
+          when Name
+          when IPv6
+            @qtype = Types.PTR
+          when IPv4
+            @qtype = Types.PTR
+          else
+            @qname = Name.create(@qname)
+        end
+      else
+        case @qtype
+          when Types.PTR
+            case @qname.to_s
+              when IPv4::Regex
+                @qname = IPv4.create(@qname).to_name
+              when IPv6::Regex
+                @qname = IPv6.create(@qname).to_name
+              when IPv6
+              when IPv4
+              else
+                @qname = Name.create(@qname)
+            end
+          else
+            @qname = Name.create(@qname)
+        end
+      end
+    end
+
+    def qtype=(qtype)
+      @qtype = Types.new(qtype)
+    end
+
+    def qclass=(qclass)
+      @qclass = Classes.new(qclass)
+    end
+
+    def qname=(qname)
+      case qname
         when IPv4::Regex
-          @qname = IPv4.create(@qname).to_name
+          @qname = IPv4.create(qname).to_name
           @qtype = Types.PTR
         when IPv6::Regex
-          @qname = IPv6.create(@qname).to_name
+          @qname = IPv6.create(qname).to_name
           @qtype = Types.PTR
         when Name
         when IPv6
@@ -1166,65 +1302,22 @@ module Dnsruby
         when IPv4
           @qtype = Types.PTR
         else
-          @qname = Name.create(@qname)
-        end
-      else
-        case @qtype
-        when Types.PTR
-          case @qname.to_s
-          when IPv4::Regex
-            @qname = IPv4.create(@qname).to_name
-          when IPv6::Regex
-            @qname = IPv6.create(@qname).to_name
-          when IPv6
-          when IPv4
-          else
-            @qname = Name.create(@qname)
-          end
-        else
-          @qname = Name.create(@qname)
-        end
+          @qname = Name.create(qname)
       end
     end
-    
-    def qtype=(qtype)
-      @qtype = Types.new(qtype)
-    end
-    
-    def qclass=(qclass)
-      @qclass = Classes.new(qclass)
-    end
-    
-    def qname=(qname)
-      case qname
-      when IPv4::Regex
-        @qname = IPv4.create(qname).to_name
-        @qtype = Types.PTR
-      when IPv6::Regex
-        @qname = IPv6.create(qname).to_name
-        @qtype = Types.PTR
-      when Name
-      when IPv6
-        @qtype = Types.PTR
-      when IPv4
-        @qtype = Types.PTR
-      else
-        @qname = Name.create(qname)
-      end
-    end
-    
+
     #Returns a string representation of the question record.
     def to_s
       return "#{@qname}.\t#{@qclass.string}\t#{@qtype.string}";
     end
-    
+
     # For Updates, the qname field is redefined to zname (RFC2136, section 2.3)
     alias zname qname
     # For Updates, the qtype field is redefined to ztype (RFC2136, section 2.3)
     alias ztype qtype
     # For Updates, the qclass field is redefined to zclass (RFC2136, section 2.3)
     alias zclass qclass
-    
+
     alias type qtype
   end
 end

--- a/test/tc_header.rb
+++ b/test/tc_header.rb
@@ -77,12 +77,6 @@ class TestHeader < Minitest::Test
     
     assert(header==(header2), 'Headers are the same');
     
-    #
-    #  Is header.inspect remotely sane?
-    #
-    assert(header.to_s =~ /opcode = Query/, 'inspect() has opcode correct');
-    assert(header.to_s =~ /ancount = 2/,    'inspect() has ancount correct');
-    
     header = Header.new;
     
     #

--- a/test/tc_message.rb
+++ b/test/tc_message.rb
@@ -1,0 +1,59 @@
+#--
+#Copyright 2007 Nominet UK
+#
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+#++
+
+require_relative 'spec_helper'
+
+class TestMessage < Minitest::Test
+
+  def sample_message
+    Dnsruby::Message.new('cnn.com', 'A')
+=begin
+;; QUESTION SECTION (1  record)
+;; cnn.com.	IN	A
+.;; Security Level : UNCHECKED
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 7195
+;; flags: ; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0
+=end
+  end
+
+  def test_question_section_formatted_ok
+    multiline_regex = /QUESTION SECTION.+record.+cnn.com.\s+IN\s+A/m
+    assert multiline_regex.match(sample_message.to_s)
+  end
+
+  def test_has_security_level_line
+    line_regex = /^;; Security Level : .+/
+    assert line_regex.match(sample_message.to_s)
+  end
+
+  def test_has_flags_and_section_count
+    line_regex = /^;; flags:.+QUERY: \d+, ANSWER: \d+, AUTHORITY: \d+, ADDITIONAL: \d+/
+    assert line_regex.match(sample_message.to_s)
+  end
+
+  def test_rd_flag_displayed_when_true
+    message = sample_message
+    message.header.instance_variable_set(:@rd, true)
+    assert /;; flags(.+)rd/.match(message.to_s), message
+  end
+
+  def test_header_line_contains_opcode_and_status_and_id
+    message = sample_message
+    header_line = message.to_s.split("\n").grep(/->>HEADER<<-/).first
+    line_regex = /->>HEADER<<- opcode: .+, status: .+, id: \d+/
+    assert line_regex.match(header_line)
+  end
+end


### PR DESCRIPTION
...it in ts_offline.rb.

 Whitespace changes by editor include stripping white space and 2 indentation levels for line continuations.

Note: I've left the old behavior in methods named old_to_s, but if you're ok with the new to_s, I should probably delete the old_to_s methods unless you think they would be useful to someone.
