### PR TITLE
Add Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: ruby
+cache: bundler
+
+script: "bundle exec rake test_offline"
+
+rvm:
+  - 1.9.3
+  - 2.0.0
+  - 2.1.4


### PR DESCRIPTION
I want to add Travis CI configuration for CI.

Now, I see the error on 1.9.3, and it is related to gemspec modification #6.
I will create another pull request for that.

You can see the [test result here](https://travis-ci.org/otahi/dnsruby/builds/39543387).
