### PR TITLE
Fix/improve .gemspec, add needed require 'dnsruby/version'.

### DIFF
--- a/dnsruby.gemspec
+++ b/dnsruby.gemspec
@@ -3,12 +3,15 @@ require_relative 'lib/dnsruby/version'
 SPEC = Gem::Specification.new do |s|
   s.name = "dnsruby"
   s.version = Dnsruby::VERSION
-  s.authors = ["AlexD"]
-  s.email = "alexd@nominet.org.uk"
+  s.authors = ["Alex Dalitz"]
+  s.email = 'alex@caerkettontech.com'
   s.homepage = "https://github.com/alexdalitz/dnsruby"
-  s.rubyforge_project = "dnsruby"
   s.platform = Gem::Platform::RUBY
   s.summary = "Ruby DNS(SEC) implementation"
+  s.description = \
+'Dnsruby is a pure Ruby DNS client library which implements a
+stub resolver. It aims to comply with all DNS RFCs, including
+DNSSEC NSEC3 support.'
   s.license = "Apache License, Version 2.0"
   candidatestest = Dir.glob("test/**/*")
   candidateslib = Dir.glob("lib/**/*")
@@ -16,15 +19,12 @@ SPEC = Gem::Specification.new do |s|
   candidatesdemo = Dir.glob("demo/**/*")
   rakefile = ['Rakefile']
   candidates = rakefile + candidatestest + candidateslib + candidatesdoc + candidatesdemo
-  s.files = candidates.delete_if do |item|
-    item.include?("CVS") || item.include?("rdoc") || item.include?("svn")
-  end
-  s.autorequire="dnsruby"
+  s.files = candidates.delete_if { |item| /rdoc$/.match(item) }
   s.test_file = "test/ts_offline.rb"
   s.has_rdoc = true
   s.extra_rdoc_files = ["DNSSEC", "EXAMPLES", "README", "EVENTMACHINE"]
 
-  s.add_development_dependency 'rake', '~> 10.3.2'
+  s.add_development_dependency 'rake', '~> 10', '>= 10.3.2'
   s.add_development_dependency 'minitest', '~> 5.4'
 end
 

--- a/lib/dnsruby.rb
+++ b/lib/dnsruby.rb
@@ -18,6 +18,7 @@ require 'dnsruby/ipv4'
 require 'dnsruby/ipv6'
 require 'timeout'
 require 'dnsruby/TheLog'
+require 'dnsruby/version'
 #= Dnsruby library
 #Dnsruby is a thread-aware DNS stub resolver library written in Ruby.
 #


### PR DESCRIPTION
- Add require 'dnsruby/version' in dnsruby.rb, was a problem when used as installed gem.
- Change author name format to "First Last" as per convention.
- Correct author email address.
- Remove rubyforge project name, no longer needed.
- Add gem multiline description.
- Remove check for 'CVS', 'svn', no longer needed.
- Make test for 'rdoc' more precise (require it be end of line).
- Remove autorequire script name, obsolete.
- Fix rake dependency version specification.
