### PR TITLE
Replace require_relative with require to rescue Ruby 1.9.3

### DIFF
--- a/dnsruby.gemspec
+++ b/dnsruby.gemspec
@@ -1,4 +1,6 @@
-require_relative 'lib/dnsruby/version'
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'dnsruby/version'
 
 SPEC = Gem::Specification.new do |s|
   s.name = "dnsruby"


### PR DESCRIPTION
For Ruby 1.9.3 dnsruby.gemspec make an error like this.

```
[otahi@otahiair dnsruby]$ rbenv local 1.9.3-p547
[otahi@otahiair dnsruby]$ bundle exec rake test_offline
There was a LoadError while loading dnsruby.gemspec:
cannot infer basepath from
  /Users/otahi/git/dnsruby/dnsruby.gemspec:1:in `require_relative'

Does it try to require a relative path? That's been removed in Ruby 1.9.
[otahi@otahiair dnsruby]$
```

I have fix this with a reference [bundler template](https://github.com/bundler/bundler/commit/6bbab44a82b8896c3249853c4bf74eef8b5749bf).

```
[otahi@otahiair dnsruby]$ git checkout rescue_ruby_1_9_3
Switched to branch 'rescue_ruby_1_9_3'
[otahi@otahiair dnsruby]$ bundle exec rake test_offline
/Users/otahi/.rbenv/versions/1.9.3-p547/bin/ruby -I"lib" -I"/Users/otahi/git/dnsruby/.bundle/vendor/bundle/ruby/1.9.1/gems/rake-10.3.2/lib" "/Users/otahi/git/dnsruby/.bundle/vendor/bundle/ruby/1.9.1/gems/rake-10.3.2/lib/rake/rake_test_loader.rb" "test/ts_offline.rb"
Run options: --seed 38404

# Running:

...........IMPLEMENT NSEC3 validation!
..............................................................................

Finished in 30.268608s, 2.9403 runs/s, 40.3058 assertions/s.

89 runs, 1220 assertions, 0 failures, 0 errors, 0 skips
[otahi@otahiair dnsruby]$
```

And Travis CI says [all test passed for Ruby versions 1.9.3, 2.0.0, 2.1.4](https://travis-ci.org/otahi/dnsruby/builds/39648886)
