### PR TITLE
Add measurement coverage with coveralls

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require 'rake/testtask'
 require 'rdoc/task'
+require 'coveralls/rake/task'
 
 Rake::RDocTask.new do |rd|
   rd.rdoc_files.include("lib/**/*.rb")
@@ -7,7 +8,6 @@ Rake::RDocTask.new do |rd|
   rd.main = "Dnsruby"
 #  rd.options << "--ri"
 end
-
 
 def create_task(task_name, test_suite_filespec)
   Rake::TestTask.new do |t|
@@ -17,6 +17,7 @@ def create_task(task_name, test_suite_filespec)
   end
 end
 
+Coveralls::RakeTask.new
 
 create_task(:test,         'test/ts_dnsruby.rb')
 create_task(:test_offline, 'test/ts_offline.rb')

--- a/dnsruby.gemspec
+++ b/dnsruby.gemspec
@@ -28,5 +28,6 @@ DNSSEC NSEC3 support.'
 
   s.add_development_dependency 'rake', '~> 10', '>= 10.3.2'
   s.add_development_dependency 'minitest', '~> 5.4'
+  s.add_development_dependency 'coveralls', '~> 0.7'
 end
 

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -1,2 +1,15 @@
+require 'coveralls'
+Coveralls.wear!
+
+require 'simplecov'
+
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+  SimpleCov::Formatter::HTMLFormatter,
+  Coveralls::SimpleCov::Formatter
+]
+SimpleCov.start do
+  add_filter 'test/'
+end
+
 require 'minitest/autorun'
 require 'dnsruby'


### PR DESCRIPTION
I am adding test coverage to dnsruby.

The test coverage shows how many percentage of lines are covered with tests.
It is a kind of metrics.

You can see the metrics if you have a [coveralls](https://coveralls.io/) account and enable this repository.
[coveralls page](https://coveralls.io/builds/1416683)
[coverage/index.html](https://dl.dropboxusercontent.com/u/12026408/dnsruby_coverage/index.html)(which are not commited)

It seems tests should be added more.
![dnsruby_coverage_image](https://cloud.githubusercontent.com/assets/1556477/4875890/622ffe02-62ac-11e4-9e62-0377c2902c38.png)
:
:
