### PR TITLE
Added test for correct handling of HS class with send_plain_message.

### DIFF
--- a/test/tc_hs.rb
+++ b/test/tc_hs.rb
@@ -1,0 +1,25 @@
+require_relative 'spec_helper'
+
+include Dnsruby
+
+class TestDNS < Minitest::Test
+
+  def setup
+    Dnsruby::Config.reset
+  end
+
+
+  # Illustrates that when a message whose class is 'HS' is sent to
+  # a DNS server that does not support the HS class, using send_plain_message,
+  # the response returns with an rcode of NOTIMP and a Dnsruby::NotImp error.
+  def test_hs_class_returns_notimp_code_and_error
+    resolver_host = 'a.gtld-servers.net'
+    resolver = Resolver.new(resolver_host)
+    message = Message.new('test.com', 'A', 'HS')
+    response, error = resolver.send_plain_message(message)
+
+    assert_equal(RCode::NOTIMP, response.rcode)
+    assert_equal(Dnsruby::NotImp, error.class)
+  end
+
+end

--- a/test/ts_online.rb
+++ b/test/ts_online.rb
@@ -40,6 +40,7 @@ if (online)
   print "It may just be that some UDP packets got lost the first time...\n"
   require_relative "tc_resolver.rb"
   require_relative "tc_dnsruby.rb"
+  require_relative "tc_hs.rb"
   #   require_relative "tc_inet6.rb"
   #   require_relative "tc_recurse.rb"
   require_relative "tc_tcp.rb"


### PR DESCRIPTION
Alex - this test illustrates that the desired behavior of which we spoke before is available using send_plain_message.  I think it would be helpful to have here, if nothing else, to document this handling, but feel free to close the pull request instead.  Also, I'm using a DNS server on the public Internet, in case that's not ok.
