### PR TITLE
Fix readme contact info, Nominet reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,6 @@ at runtime:
 bundle exec rake test
 ```
 
-Nominet operates a test server which the Dnsruby test code queries.
-If this server is not available then some of the online tests will
-not be run.
-
-
 Usage Help
 ----------
 


### PR DESCRIPTION
For Contact links, fix formatting and add Google group and Rubygems link.
Remove reference to Nominet test servers, which are no longer used.
