### PR TITLE
Add sudo: false configuration for faster build on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 cache: bundler
+sudo: false
 
 script: "bundle exec rake test"
 


### PR DESCRIPTION
I have changed .travis.yml for faster build on Travis CI according to [Faster Builds with Container-Based Infrastructure and Docker](http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/)

This change seems to make a build faster.
![travis-buildtime](https://cloud.githubusercontent.com/assets/1556477/5551195/0739d636-8c04-11e4-8c46-26c8e098ab9a.png)
