### PR TITLE
Fix zone reader adding unwanted dot to relative hostnames being converted to absolute

### DIFF
--- a/lib/dnsruby/zone_reader.rb
+++ b/lib/dnsruby/zone_reader.rb
@@ -355,7 +355,7 @@ module Dnsruby
             Types::PTR, Types::DNAME].include?type_was)
         #         if (line[line.length-1, 1] != ".")
         if (!(/\.\z/ =~ line))
-          line = line + "." + @origin.to_s + "."
+          line = line + "." + @origin.to_s
         end
       end
       #  Other RRs have several names. These should be parsed by Dnsruby,

--- a/test/tc_zone_reader.rb
+++ b/test/tc_zone_reader.rb
@@ -47,7 +47,7 @@ ZONEDATA
     assert_equal("\"v=spf1 mx ~all\"", zone[4].rdata)
     assert_equal("192.0.2.10", zone[5].rdata)
     assert_equal("2001:DB8::10", zone[6].rdata)
-    #assert_equal("www.example.com.", zone[7].rdata)
+    assert_equal("www.example.com.", zone[7].rdata)
     assert_equal("www.example.com.", zone[8].rdata)
   end
 


### PR DESCRIPTION
This fixes a bug where the zone reader would add @origin.to_s + "." to relative hostnames in the record data. Since @origin already ends with a dot, the result would be the hostname ending in two dots, which is invalid.
I also uncommented the test case I wrote for it in my last pull request.