### PR TITLE
Fix Resolver#create_tsig_options visibility.

### DIFF
--- a/lib/dnsruby/resolver.rb
+++ b/lib/dnsruby/resolver.rb
@@ -707,7 +707,7 @@ module Dnsruby
       end
 
       options
-    end; private :create_tsig_options
+    end
 
 
     def Resolver.get_tsig(args)

--- a/lib/dnsruby/resolver.rb
+++ b/lib/dnsruby/resolver.rb
@@ -682,12 +682,9 @@ module Dnsruby
     end
 
     #  Sets the TSIG to sign outgoing messages with.
-    #  Pass in either a Dnsruby::RR::TSIG, or a key_name and key (or just a key)
     #  Pass in nil to stop tsig signing.
-    #  * res.tsig=(tsig_rr)
-    #  * res.tsig=(key_name, key) # defaults to hmac-md5
-    #  * res.tsig=(key_name, key, alg) # e.g. alg = 'hmac-sha1'
-    #  * res.tsig=nil # Stop the resolver from signing
+    #  * res.tsig = tsig_rr
+    #  * res.tsig = nil # Stop the resolver from signing
     def tsig=(t)
       @tsig = t
       update

--- a/test/tc_dnsruby.rb
+++ b/test/tc_dnsruby.rb
@@ -15,6 +15,7 @@
 # ++
 
 require_relative 'spec_helper'
+require 'resolv'
 
 include Dnsruby
 class TestDnsruby < Minitest::Test


### PR DESCRIPTION
* Make Resolver#create_tsig_options public instead of private to fix error. 
* Add require to tc_dnsruby.rb so it will pass when called individually.
