### PR TITLE
Fix args passed to create_tsig_opts

### DIFF
--- a/lib/dnsruby/resolver.rb
+++ b/lib/dnsruby/resolver.rb
@@ -722,7 +722,7 @@ module Dnsruby
           if args[0].instance_of?(RR::TSIG)
             tsig = args[0]
           elsif args[0].instance_of?(Array)
-            tsig = RR.new_from_hash(create_tsig_options(args))
+            tsig = RR.new_from_hash(create_tsig_options(args[0]))
           end
         else
           #           Dnsruby.log.debug{'TSIG signing switched off'}


### PR DESCRIPTION
Wrong argument is passed to the create_tsig_options in the Resolver.get_tsig function.
The function checks if args[0] is an Array and then it passes just args.
Fixing this makes AXFR w/ TSIG work again.

This is a sample working code.

```ruby
require 'dnsruby'
res = Dnsruby::Resolver.new

server = '127.0.0.1'
zone = 'example.com'

KEY_NAME = "dns-server.example.com"
KEY = "wI6XiocuMR8X/DySzKVbp2SdzZZeXCsQLjEs6HRlnkY=";

zt = Dnsruby::ZoneTransfer.new
zt.server = server
zt.transfer_type = Dnsruby::Types.AXFR
zt.tsig= KEY_NAME, KEY

zoneref = zt.transfer(zone)
```