### PR TITLE
Add code to require all Ruby files in and under lib/dnsruby.

### DIFF
--- a/lib/dnsruby.rb
+++ b/lib/dnsruby.rb
@@ -28,6 +28,15 @@ require 'dnsruby/zone_transfer'
 require 'dnsruby/dnssec'
 require 'dnsruby/zone_reader'
 
+# Now, require all other files in the lib/dnsruby directory and below
+# that were not already required by the requires above.
+#
+# This is a self invoking anonymous lambda to confine the scope of its locals.
+-> do
+  this_file_dir = File.dirname(__FILE__)
+  files_to_require = Dir[File.join(this_file_dir, 'dnsruby', '**', '*.rb')]
+  files_to_require.each { |file| require file }
+end.()
 
 # = Dnsruby library
 # Dnsruby is a thread-aware DNS stub resolver library written in Ruby.

--- a/lib/dnsruby.rb
+++ b/lib/dnsruby.rb
@@ -27,16 +27,8 @@ require 'dnsruby/update'
 require 'dnsruby/zone_transfer'
 require 'dnsruby/dnssec'
 require 'dnsruby/zone_reader'
+require 'dnsruby/resolv'
 
-# Now, require all other files in the lib/dnsruby directory and below
-# that were not already required by the requires above.
-#
-# This is a self invoking anonymous lambda to confine the scope of its locals.
--> do
-  this_file_dir = File.dirname(__FILE__)
-  files_to_require = Dir[File.join(this_file_dir, 'dnsruby', '**', '*.rb')]
-  files_to_require.each { |file| require file }
-end.()
 
 # = Dnsruby library
 # Dnsruby is a thread-aware DNS stub resolver library written in Ruby.


### PR DESCRIPTION
We have some explicit requires (requires of specific files) in lib/dnsruby.rb.

While there may be some recursive requiring going on, not all the files are required as a result.  For example:

```
2.1.4 :001 > require 'dnsruby'
 => true
2.1.4 :002 > Dnsruby::Resolv
NameError: uninitialized constant Dnsruby::Resolv
```

This code modification requires all files in lib/dnsruby and below.  This is the simplest way to guarantee that all files are included.  The expansion of the wild card will also include the files already explicitly required, but require will notice this and not try to require the file again, so this is not a problem.
