### PR TITLE
Fixed Resolv error when address passed was already an IP address.

### DIFF
--- a/lib/dnsruby/resolv.rb
+++ b/lib/dnsruby/resolv.rb
@@ -74,7 +74,7 @@ class Resolv
 
   # Looks up all IP addresses for +name+
   def getaddresses(name)
-    return name if ADDRESS_REGEX.match(name)
+    return [name] if ADDRESS_REGEX.match(name)
     @resolvers.each do |resolver|
       addresses = []
       resolver.each_address(name) { |address| addresses << address }

--- a/test/tc_resolv.rb
+++ b/test/tc_resolv.rb
@@ -65,4 +65,9 @@ class TestResolv < Minitest::Test
     assert_equal(RELATIVE_NAME, names.first.to_s)
     Dnsruby::Resolv.each_name(IPV4_ADDR) { |name| assert_equal(RELATIVE_NAME, name.to_s)}
   end
+
+  def test_resolv_address_to_address
+    local = '127.0.0.1'
+    assert_equal(local, Dnsruby::Resolv.new.getaddress(local))
+  end
 end


### PR DESCRIPTION
This is a simple change but fixes a bad bug where trying to ask getaddress for the address of an IP address raises an error, but only on Linux, not on Mac OS.  I've added a test to verify the bug and the fix.  Here was the output of the failing test before the fix was applied:

  1) Error:
TestResolv#test_resolv_address_to_address:
NoMethodError: undefined method `first' for "127.0.0.1":String
    /home/kbennett/dnsruby/lib/dnsruby/resolv.rb:71:in `getaddress'
    /home/kbennett/dnsruby/test/tc_resolv.rb:71:in `test_resolv_address_to_address'
