### PR TITLE
Removed "Note:" comments added in the previous commit.

### DIFF
--- a/lib/dnsruby/packet_sender.rb
+++ b/lib/dnsruby/packet_sender.rb
@@ -401,7 +401,6 @@ module Dnsruby
         @pipeline_socket = Socket.new(AF_INET, SOCK_STREAM, 0)
         @pipeline_socket.bind(Addrinfo.tcp(src_address, src_port))
         @pipeline_socket.connect(sockaddr)
-        # NOTE: Moved this here from ||= 0 a few lines below.
         @use_counts[@pipeline_socket] = 0
       end
 

--- a/lib/dnsruby/select_thread.rb
+++ b/lib/dnsruby/select_thread.rb
@@ -370,9 +370,6 @@ module Dnsruby
     end
 
     def remove_id(id)
-      # NOTE: I removed the following, which were never used:
-      # socket=nil
-      # close_socket = true
 
       @@mutex.synchronize do
         socket = @@query_hash[id].socket

--- a/test/tc_soak.rb
+++ b/test/tc_soak.rb
@@ -162,7 +162,6 @@ class TestSingleResolverSoak < Minitest::Test
     receive_thread.join
 
     time_taken = Time.now - start
-    # NOTE: I changed the 'p' calls to 'puts' because p was printing quote chars, is that ok?
     puts "Query count : #{query_count}, #{timeout_count} timed out. #{time_taken} time taken"
     assert(timeout_count < query_count * 0.1, "#{timeout_count} of #{query_count} timed out!")
   end

--- a/test/tc_tcp_pipelining.rb
+++ b/test/tc_tcp_pipelining.rb
@@ -93,10 +93,7 @@ class TestTCPPipelining < Minitest::Test
         port:                       TCPPipeliningServer::PORT)
   end
 
-  # Send a x number of queries asynchronously to our resolver
-
-  # NOTE: Since durations can be in different units, this name is clearer.
-
+  # Send x number of queries asynchronously to our resolver
   def send_async_messages(number_of_messages, queue, wait_seconds = 0)
     query_cycler = QUERIES.cycle
     number_of_messages.times do
@@ -114,7 +111,6 @@ class TestTCPPipelining < Minitest::Test
   # Verify x responses with no exception
   def verify_responses(number_of_messages, queue)
     number_of_messages.times do
-      # NOTE: Leading '_' indicates it's unused.
       _response_id, response, exception = queue.pop
       assert_nil(exception)
       assert(response.is_a?(Dnsruby::Message))


### PR DESCRIPTION
Also removed exception handling in NioTcpPipeliningHandler selector thread as per @nwitkowski.
Minor refactor of method that creates the selector thread.