### PR TITLE
Add Message#add_answer! method.

### DIFF
--- a/lib/dnsruby/message/message.rb
+++ b/lib/dnsruby/message/message.rb
@@ -290,13 +290,26 @@ module Dnsruby
       @header.nscount = @authority.length
     end
 
-
-    def add_answer(rr) #:nodoc: all
-      unless @answer.include?(rr)
+    def _add_answer(rr, force = false)
+      if force || (! @answer.include?(rr))
         @answer << rr
         update_counts
       end
+    end; private :_add_answer
+
+    # Adds an RR to the answer section unless it already occurs.
+    def add_answer(rr) #:nodoc: all
+      _add_answer(rr)
     end
+
+    # When adding an RR to a Dnsruby::Message, add_answer checks to see if it already occurs,
+    # and, if so, does not add it again. This method adds the record whether or not
+    # it already occurs.  This is needed in order to add
+    # a SOA record twice for an AXFR response.
+    def add_answer!(rr)
+      _add_answer(rr, true)
+    end
+
 
     def each_answer
       @answer.each {|rec|

--- a/test/tc_rr.rb
+++ b/test/tc_rr.rb
@@ -328,4 +328,26 @@ class TestRR < Minitest::Test
     assert_equal a1.hash, a2.hash
     assert_equal a1.hash, a3.hash
   end
+
+  def _test_duplicate_answer(method_as_symbol)
+    expected_count = case method_as_symbol
+    when :add_answer
+      1
+    when :add_answer!
+      2
+    end
+
+    rr = RR.new_from_string 'techhumans.com. 1111 IN A 69.89.31.97'
+    message = Message.new
+    2.times { message.send(method_as_symbol, rr) }
+    assert_equal(expected_count, message.header.ancount)
+  end
+
+  def test_add_dup_answer_no_force
+    _test_duplicate_answer(:add_answer)
+  end
+
+  def test_add_dup_answer_force
+    _test_duplicate_answer(:add_answer!)
+  end
 end


### PR DESCRIPTION
When adding an RR to a Dnsruby::Message, the original add_answer method checks to see if it already occurs, and, if so, does not add it again. 

This is a problem in the case of an AXFR response, where a SOA record needs to be added twice.  The add_answer! method added in this pull request allows the answer record to be answered whether or not it already occurs.