### PR TITLE
disable caching for SOA lookups

### DIFF
--- a/demo/check_soa.rb
+++ b/demo/check_soa.rb
@@ -107,6 +107,8 @@ def process_ns_domain(resolver, domain, ns_domain)
     # ----------------------------------------------------------------------
     ip_address = a_answer.address
     resolver.nameserver = ip_address.to_s
+    # disable caching otherwise SOA is cached from first nameserver queried
+    resolver.do_caching = false
     print "#{ns_domain} (#{ip_address}): "
 
     # ----------------------------------------------------------------------


### PR DESCRIPTION
SOA result gets cached from the first nameserver queried, resulting in the below example (all are authoritative, and the ns1 server is running an old version).

    $ ./demo/check_soa.rb example.net
    ns2.company.dns.example.net (123.34.255.73): has serial number 2
    ns1.company.dns.example.net (123.34.234.248): isn't authoritative for example.com
    ns3.company.dns.example.net (50.17.205.23): isn't authoritative for example.com
    $ ./demo/check_soa.rb example.com
    ns3.company.dns.example.net (50.17.205.23): has serial number 2
    ns2.company.dns.example.net (123.34.255.73): isn't authoritative for example.com
    ns1.company.dns.example.net (123.34.234.248): isn't authoritative for example.com
    $ ./demo/check_soa.rb example.com
    ns1.company.dns.example.net (123.34.234.248): has serial number 1
    ns3.company.dns.example.net (50.17.205.23): isn't authoritative for example.com
    ns2.company.dns.example.net (123.34.255.73): isn't authoritative for example.com

