### PR TITLE
Add support for HMAC SHA512 TSIG keys

### DIFF
--- a/lib/dnsruby/resource/TSIG.rb
+++ b/lib/dnsruby/resource/TSIG.rb
@@ -54,6 +54,7 @@ module Dnsruby
       HMAC_MD5 = Name.create("HMAC-MD5.SIG-ALG.REG.INT.")
       HMAC_SHA1 = Name.create("hmac-sha1.")
       HMAC_SHA256 = Name.create("hmac-sha256.")
+      HMAC_SHA512 = Name.create("hmac-sha512.")
 
       DEFAULT_FUDGE     = 300
 
@@ -157,6 +158,8 @@ module Dnsruby
           mac = OpenSSL::HMAC.digest(OpenSSL::Digest::SHA1.new, key, data)
         elsif (algorithm == HMAC_SHA256)
           mac = OpenSSL::HMAC.digest(OpenSSL::Digest::SHA256.new, key, data)
+        elsif (algorithm == HMAC_SHA512)
+          mac = OpenSSL::HMAC.digest(OpenSSL::Digest::SHA512.new, key, data)
         else
           #  Should we allow client to pass in their own signing function?
           raise VerifyError.new("Algorithm #{algorithm} unsupported by TSIG")
@@ -515,6 +518,7 @@ module Dnsruby
       # * hmac-md5
       # * hmac-sha1
       # * hmac-sha256
+      # * hmac-sha512
       def algorithm=(alg)
         if (alg.class == String)
           if (alg.downcase=="hmac-md5")
@@ -523,11 +527,13 @@ module Dnsruby
             @algorithm = HMAC_SHA1;
           elsif (alg.downcase=="hmac-sha256")
             @algorithm = HMAC_SHA256;
+          elsif (alg.downcase=="hmac-sha512")
+            @algorithm = HMAC_SHA512;
           else
             raise ArgumentError.new("Invalid TSIG algorithm")
           end
         elsif (alg.class == Name)
-          if (alg!=HMAC_MD5 && alg!=HMAC_SHA1 && alg!=HMAC_SHA256)
+          if (alg!=HMAC_MD5 && alg!=HMAC_SHA1 && alg!=HMAC_SHA256 && alg!=HMAC_SHA512)
             raise ArgumentException.new("Invalid TSIG algorithm")
           end
           @algorithm=alg


### PR DESCRIPTION
Offline tests still pass.  Online tests still fail.  No change to tests, since only md5 algo is being tested.

```shell
$ rake test_offline
/home/junk/.rvm/rubies/ruby-2.0.0-p643/bin/ruby -I"lib" -I"/home/junk/.rvm/gems/ruby-2.0.0-p643@global/gems/rake-10.4.2/lib" "/home/junk/.rvm/gems/ruby-2.0.0-p643@global/gems/rake-10.4.2/lib/rake/rake_test_loader.rb" "test/ts_offline.rb"
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
Run options: --seed 17350

# Running:

.........................................................................................................................

Finished in 2.809492s, 43.0683 runs/s, 464.8528 assertions/s.

121 runs, 1306 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for Unit Tests to /home/junk/git/altiscale/dnsruby/coverage. 5604 / 7926 LOC (70.7%) covered.
[Coveralls] Outside the CI environment, not sending data.
```