### PR TITLE
ruby 2.3.0 deprecates TimeoutError, use Timeout::Error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.4
+  - 2.3.0
   - jruby-19mode
 #  - rbx-2
   - ruby-head

--- a/lib/dnsruby.rb
+++ b/lib/dnsruby.rb
@@ -161,7 +161,7 @@ module Dnsruby
   end
 
   # A timeout error raised while querying for a resource
-  class ResolvTimeout < TimeoutError
+  class ResolvTimeout < Timeout::Error
   end
 
   # The requested domain does not exist

--- a/lib/dnsruby.rb
+++ b/lib/dnsruby.rb
@@ -76,7 +76,7 @@ require 'dnsruby/resolv'
 # 
 # * ResolvError < StandardError
 # 
-# * ResolvTimeout < TimeoutError
+# * ResolvTimeout < Timeout::Error
 # 
 # * NXDomain < ResolvError
 # 


### PR DESCRIPTION
Fixes the following deprecation error notice: 

```
/usr/local/lib/ruby/gems/2.3.0/gems/dnsruby-1.59.1/lib/dnsruby.rb:164: warning: constant Dnsruby::TimeoutError is deprecated
```

I don't know if this will have issues with older rubies. Hopefully travis catches them.