### PR TITLE
Fix issue where an update to delete a CNAME was missing the rdata/mal…

### DIFF
--- a/lib/dnsruby/message/decoder.rb
+++ b/lib/dnsruby/message/decoder.rb
@@ -134,6 +134,8 @@ class MessageDecoder #:nodoc: all
           labels += self.get_labels(limit)
           @index = save_index
           return labels
+        when nil
+          return labels
         else
           labels << self.get_label
       end

--- a/lib/dnsruby/resource/domain_name.rb
+++ b/lib/dnsruby/resource/domain_name.rb
@@ -1,12 +1,12 @@
 # --
 # Copyright 2007 Nominet UK
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -43,13 +43,17 @@ module Dnsruby
       end
 
       def encode_rdata(msg, canonical=false) #:nodoc: all
-        if (klass != Classes::NONE)
+        if !([Classes::NONE, Classes::ANY].include? klass) || @rdata.length > 0
           msg.put_name(@domainname, canonical)
         end
       end
 
       def self.decode_rdata(msg) #:nodoc: all
-        return self.new(msg.get_name)
+        n = msg.get_name
+        if n.length == 0
+          n = nil
+        end
+        self.new(n)
       end
     end
   end


### PR DESCRIPTION
…formed.

Add tests to better verify that the absent cname request on an update produces the right encoding as well as verifying deleting a cname with a specific rdata or any cname of a given name works