### PR TITLE
Move `include dnsruby` inside class

### DIFF
--- a/lib/dnsruby/packet_sender.rb
+++ b/lib/dnsruby/packet_sender.rb
@@ -16,8 +16,10 @@
 require 'dnsruby/select_thread'
 require 'ipaddr'
 # require 'dnsruby/iana_ports'
-include Socket::Constants
 module Dnsruby
+
+  include Socket::Constants
+
   class PacketSender # :nodoc: all
     @@authoritative_cache = Cache.new
     @@recursive_cache = Cache.new

--- a/lib/dnsruby/packet_sender.rb
+++ b/lib/dnsruby/packet_sender.rb
@@ -18,9 +18,10 @@ require 'ipaddr'
 # require 'dnsruby/iana_ports'
 module Dnsruby
 
-  include Socket::Constants
-
   class PacketSender # :nodoc: all
+
+    include Socket::Constants
+
     @@authoritative_cache = Cache.new
     @@recursive_cache = Cache.new
 
@@ -404,7 +405,7 @@ module Dnsruby
         @tcp_pipeline_local_port = src_port
         src_address = @ipv6 ? @src_address6 : @src_address
         begin
-          @pipeline_socket = Socket.new(AF_INET, SOCK_STREAM, 0)
+          @pipeline_socket = Socket.new(Socket::AF_INET, Socket::SOCK_STREAM, 0)
           @pipeline_socket.bind(Addrinfo.tcp(src_address, src_port))
           @pipeline_socket.connect(sockaddr)
           Dnsruby.log.debug("Creating socket #{src_address}:#{src_port}")

--- a/test/tc_cache.rb
+++ b/test/tc_cache.rb
@@ -16,9 +16,10 @@
 
 require_relative 'spec_helper'
 
-include Dnsruby
-
 class TestCache < Minitest::Test
+
+  include Dnsruby
+
   def test_cache
     cache = Cache.new
     m1 = Message.new("example.com.", Types.A, Classes.IN)

--- a/test/tc_dlv.rb
+++ b/test/tc_dlv.rb
@@ -16,9 +16,10 @@
 
 require_relative 'spec_helper'
 
-include Dnsruby
-
 class TestDlv < Minitest::Test
+
+  include Dnsruby
+
   def test_dlv
     #  Enable DLV (only) for validation.
     #  Try to validate some records which can only be done through dlv

--- a/test/tc_dns.rb
+++ b/test/tc_dns.rb
@@ -16,8 +16,10 @@
 
 require_relative 'spec_helper'
 
-include Dnsruby
 class TestDNS < Minitest::Test
+
+  include Dnsruby
+
   def setup
     Dnsruby::Config.reset
   end

--- a/test/tc_ds.rb
+++ b/test/tc_ds.rb
@@ -20,6 +20,9 @@ require 'openssl'
 require 'digest/sha2'
 
 class DsTest < Minitest::Test
+
+  include Dnsruby
+
   DLVINPUT = "dskey.example.com. 86400 IN DLV 60485 5 1 ( 2BB183AF5F22588179A53B0A" +
     "98631FAD1A292118 )"
   INPUT = "dskey.example.com. 86400 IN DS 60485 5 1 ( 2BB183AF5F22588179A53B0A" +
@@ -37,7 +40,7 @@ class DsTest < Minitest::Test
       DS2 = "dskey.example.com. 86400 IN DS 60485 5 2   ( D4B7D520E7BB5F0F67674A0C"+
                                                 "CEB1E3E0614B93C4F9E99B83"+
                                                 "83F6A1E4469DA50A )"
-  include Dnsruby
+
   def test_ds_from_string
     ds = Dnsruby::RR.create(INPUT)
     assert_equal(60485, ds.key_tag)

--- a/test/tc_escapedchars.rb
+++ b/test/tc_escapedchars.rb
@@ -16,8 +16,10 @@
 
 require_relative 'spec_helper'
 
-include Dnsruby
 class TestEscapedChars < Minitest::Test
+
+  include Dnsruby
+
   def test_one
     Name::Label.set_max_length(150)
     # 

--- a/test/tc_gpos.rb
+++ b/test/tc_gpos.rb
@@ -2,10 +2,10 @@ require_relative 'spec_helper'
 
 require_relative '../lib/dnsruby/resource/GPOS.rb'
 
-include Dnsruby
-
 # Tests GPOS resource record.  See bottom of file for sample zone file.
 class TestGPOS < Minitest::Test
+
+  include Dnsruby
 
   EXAMPLE_LONGITUDE  = '10.0'
   EXAMPLE_LATITUDE   = '20.0'

--- a/test/tc_header.rb
+++ b/test/tc_header.rb
@@ -16,8 +16,10 @@
 
 require_relative 'spec_helper'
 
-include Dnsruby
 class TestHeader < Minitest::Test
+
+  include Dnsruby
+
   def test_header
     header = Header.new();
     assert(header, "new() returned something")

--- a/test/tc_hip.rb
+++ b/test/tc_hip.rb
@@ -17,8 +17,10 @@
 
 require_relative 'spec_helper'
 
-include Dnsruby
 class TestHIP < Minitest::Test
+
+  include Dnsruby
+
   def test_hip
     [{"www.example.com.      IN  HIP ( 2 200100107B1A74DF365639CC39F1D578
                                 AwEAAbdxyhNuSutc5EMzxTs9LBPCIkOFH8cIvM4p9+LrV4e19WzK00+CI6zBCQTdtWsuxKbWIy87UOoJTwkUs7lBu+Upr1gsNrut79ryra+bSRGQb1slImA8YVJyuIDsj7kwzG7jnERNqnWxZ48AWkskmdHaVDP4BcelrTI3rMXdXF5D )" =>

--- a/test/tc_ipseckey.rb
+++ b/test/tc_ipseckey.rb
@@ -17,8 +17,10 @@
 
 require_relative 'spec_helper'
 
-include Dnsruby
 class TestIPSECKEY < Minitest::Test
+
+  include Dnsruby
+
   def test_ipseckey
     [{"38.1.0.192.in-addr.arpa. 7200 IN     IPSECKEY ( 10 3 2
                     mygateway.example.com.

--- a/test/tc_name.rb
+++ b/test/tc_name.rb
@@ -16,8 +16,10 @@
 
 require_relative 'spec_helper'
 
-include Dnsruby
 class TestName < Minitest::Test
+
+  include Dnsruby
+
   def test_label_length
     Name::Label.set_max_length(Name::Label::MaxLabelLength) # Other tests may have changed this
     #  Test max label length = 63

--- a/test/tc_naptr.rb
+++ b/test/tc_naptr.rb
@@ -16,8 +16,10 @@
 
 require_relative 'spec_helper'
 
-include Dnsruby
 class TestNAPTR < Minitest::Test
+
+  include Dnsruby
+
   def test_naptr
     txt = "example.com. IN NAPTR 100  50  \"s\"  \"z3950+I2L+I2C\"     \"\"  _z3950._tcp.gatech.edu."
     naptr = RR.create(txt)

--- a/test/tc_nsec.rb
+++ b/test/tc_nsec.rb
@@ -16,12 +16,12 @@
 
 require_relative 'spec_helper'
 
-include Dnsruby
-
 class NsecTest < Minitest::Test
+
+  include Dnsruby
+
   INPUT = "alfa.example.com. 86400 IN NSEC host.example.com. ( " +
     "A MX RRSIG NSEC TYPE1234 )"
-  include Dnsruby
   def test_nsec_from_string
     nsec = Dnsruby::RR.create(INPUT)
     assert_equal("host.example.com", nsec.next_domain.to_s)

--- a/test/tc_nsec3.rb
+++ b/test/tc_nsec3.rb
@@ -17,11 +17,13 @@
 require_relative 'spec_helper'
 
 class Nsec3Test < Minitest::Test
+
+  include Dnsruby
+
   INPUT = "2t7b4g4vsa5smi47k61mv5bv1a22bojr.example. 3600 IN NSEC3 1 1 12 aabbccdd ( " +
     "2vptu5timamqttgl4luu9kg21e0aor3s A RRSIG )"
   INPUT2 = "2t7b4g4vsa5smi47k61mv5bv1a22bojr.example. 3600 IN NSEC3 1 1 12 aabbccdd " +
     "2vptu5timamqttgl4luu9kg21e0aor3s"
-  include Dnsruby
   def test_nsec_from_string
     nsec = Dnsruby::RR.create(INPUT)
 #    assert_equal(H("x.y.w.example"), nsec.next_hashed.to_s)

--- a/test/tc_nsec3param.rb
+++ b/test/tc_nsec3param.rb
@@ -17,9 +17,11 @@
 require_relative 'spec_helper'
 
 class Nsec3ParamTest < Minitest::Test
-  INPUT = "example. 3600 IN NSEC3PARAM 1 0 12 aabbccdd"
 
   include Dnsruby
+
+  INPUT = "example. 3600 IN NSEC3PARAM 1 0 12 aabbccdd"
+
   def test_nsec_from_string
     nsec = Dnsruby::RR.create(INPUT)
 

--- a/test/tc_nxt.rb
+++ b/test/tc_nxt.rb
@@ -3,10 +3,10 @@ require_relative 'spec_helper'
 require_relative '../lib/dnsruby/resource/NXT'
 require_relative '../lib/dnsruby/code_mappers'
 
-include Dnsruby
-
 # Tests NXT resource record.  See bottom of file for sample zone file.
 class TestNXT < Minitest::Test
+
+  include Dnsruby
 
   # Get this by running the following script:
   # require 'dnsruby'

--- a/test/tc_packet.rb
+++ b/test/tc_packet.rb
@@ -16,8 +16,10 @@
 
 require_relative 'spec_helper'
 
-include Dnsruby
 class TestPacket < Minitest::Test
+
+  include Dnsruby
+
   def test_packet
     domain = "example.com."
     type = "MX"

--- a/test/tc_packet_unique_push.rb
+++ b/test/tc_packet_unique_push.rb
@@ -16,8 +16,10 @@
 
 require_relative 'spec_helper'
 
-include Dnsruby
 class TestPacketUniquePush < Minitest::Test
+
+  include Dnsruby
+
   #   def test_packUniquePush
   # 
   # 

--- a/test/tc_ptrin.rb
+++ b/test/tc_ptrin.rb
@@ -1,7 +1,8 @@
 require_relative 'spec_helper'
 
-include Dnsruby
 class TestPtrIn < Minitest::Test
+
+  include Dnsruby
 
   # Tests that message raises no error when decoded, encoded, and decoded again.
   def verify(message_data_as_hex_string, canonical = false)

--- a/test/tc_question.rb
+++ b/test/tc_question.rb
@@ -16,8 +16,10 @@
 
 require_relative 'spec_helper'
 
-include Dnsruby
 class TestQuestion < Minitest::Test
+
+  include Dnsruby
+
   def test_question
     domain = "example.com"
     type = Types.MX

--- a/test/tc_res_env.rb
+++ b/test/tc_res_env.rb
@@ -16,8 +16,10 @@
 
 require_relative 'spec_helper'
 
-include Dnsruby
 class TestResolverEnv < Minitest::Test
+
+  include Dnsruby
+
 # @todo@ Dnsruby does not provide this functionality
   def test_res_env
     ENV['RES_NAMESERVERS'] = '10.0.1.128 10.0.2.128';

--- a/test/tc_res_opt.rb
+++ b/test/tc_res_opt.rb
@@ -16,8 +16,10 @@
 
 require_relative 'spec_helper'
 
-include Dnsruby
 class TestResOpt < Minitest::Test
+
+  include Dnsruby
+
   def test_dns_file
 
     #  .txt because this test will run under windows, unlike the other file

--- a/test/tc_resolv.rb
+++ b/test/tc_resolv.rb
@@ -17,7 +17,6 @@
 require_relative 'spec_helper'
 require_relative '../lib/dnsruby/resolv'
 
-include Dnsruby
 class TestResolv < Minitest::Test
 
   RELATIVE_NAME = 'google-public-dns-a.google.com'
@@ -56,7 +55,7 @@ class TestResolv < Minitest::Test
 
     assert_equal(RELATIVE_NAME, Dnsruby::Resolv.getname(IPV4_ADDR).to_s)
 
-    assert_raises(Dnsruby::Resolv::ResolvError) do
+    assert_raises(Dnsruby::ResolvError) do
       Dnsruby::Resolv.getname(RELATIVE_NAME)
     end
 

--- a/test/tc_resolver.rb
+++ b/test/tc_resolver.rb
@@ -17,7 +17,6 @@ require_relative 'spec_helper'
 
 require 'socket'
 
-include Dnsruby
 # @TODO@ We also need a test server so we can control behaviour of server to test
 # different aspects of retry strategy.
 # Of course, with Ruby's limit of 256 open sockets per process, we'd need to run
@@ -180,7 +179,7 @@ class TestResolver < Minitest::Test
       #  Work out what time should be, then time it to check
       expected = ((2**(retry_times-1))*retry_delay) + packet_timeout
       begin
-        res = Resolver.new({:nameserver => "10.0.1.128"})
+        res = Dnsruby::Resolver.new({:nameserver => "10.0.1.128"})
         #       res = Resolver.new({:nameserver => "213.248.199.17"})
         res.packet_timeout=packet_timeout
         res.retry_times=retry_times
@@ -191,13 +190,13 @@ class TestResolver < Minitest::Test
       rescue ResolvTimeout
         stop=Time.now
         time = stop-start
-        assert(time <= expected *1.3 && time >= expected *0.9, "Wrong time take, expected #{expected}, took #{time}")
+        assert(time <= expected * 1.3 && time >= expected * 0.9, "Wrong time take, expected #{expected}, took #{time}")
       end
   end
   end
 
   def test_packet_timeout
-        res = Resolver.new({:nameserver => []})
+        res = Dnsruby::Resolver.new({:nameserver => []})
 #      res = Resolver.new({:nameserver => "10.0.1.128"})
       start=stop=0
       retry_times = retry_delay = packet_timeout= 10
@@ -212,16 +211,16 @@ class TestResolver < Minitest::Test
         start=Time.now
         m = res.send_message(Message.new("a.t.dnsruby.validation-test-servers.nominet.org.uk", Types.A))
         fail
-      rescue ResolvTimeout
+      rescue Dnsruby::ResolvTimeout
         stop=Time.now
         time = stop-start
-        assert(time <= expected *1.3 && time >= expected *0.9, "Wrong time take, expected #{expected}, took #{time}")
+        assert(time <= expected * 1.3 && time >= expected * 0.9, "Wrong time take, expected #{expected}, took #{time}")
       end    #
   end
 
   def test_queue_packet_timeout
 #    if (!RUBY_PLATFORM=~/darwin/)
-      res = Resolver.new({:nameserver => "10.0.1.128"})
+      res = Dnsruby::Resolver.new({:nameserver => "10.0.1.128"})
 #      bad = SingleResolver.new("localhost")
       res.add_server("localhost")
       expected = 2
@@ -235,14 +234,14 @@ class TestResolver < Minitest::Test
       assert(ret==nil)
       assert(err.class == ResolvTimeout, "#{err.class}, #{err}")
       time = stop-start
-      assert(time <= expected *1.3 && time >= expected *0.9, "Wrong time take, expected #{expected}, took #{time}")
+      assert(time <= expected * 1.3 && time >= expected * 0.9, "Wrong time take, expected #{expected}, took #{time}")
 #    end
   end
 
   def test_illegal_src_port
     #  Also test all singleresolver ports ok
     #  Try to set src_port to an illegal value - make sure error raised, and port OK
-    res = Resolver.new
+    res = Dnsruby::Resolver.new
     res.port = 56789
     tests = [53, 387, 1265, 3210, 48619]
     tests.each do |bad_port|
@@ -300,7 +299,7 @@ class TestRawQuery < Minitest::Test
   # Returns a new resolver whose send_plain_message method always returns
   # nil for the response, and a RuntimeError for the error.
   def resolver_returning_error
-    resolver = Resolver.new
+    resolver = Dnsruby::Resolver.new
     def resolver.send_plain_message(_message)
       [nil, CustomError.new]
     end
@@ -311,7 +310,7 @@ class TestRawQuery < Minitest::Test
   # :response_from_send_plain_message instead of a real Dnsruby::Message,
   # for easy comparison in the tests.
   def resolver_returning_response
-    resolver = Resolver.new
+    resolver = Dnsruby::Resolver.new
     def resolver.send_plain_message(_message)
       [:response_from_send_plain_message, nil]
     end

--- a/test/tc_rr-opt.rb
+++ b/test/tc_rr-opt.rb
@@ -18,10 +18,9 @@ require_relative 'spec_helper'
 
 require 'socket'
 
-include Dnsruby
 class TestRrOpt < Minitest::Test
 
-
+  include Dnsruby
 
   # This test illustrates that when an OPT record specifying a maximum
   # UDP size is added to a query, the server will respect that setting

--- a/test/tc_rr-txt.rb
+++ b/test/tc_rr-txt.rb
@@ -16,8 +16,10 @@
 
 require_relative 'spec_helper'
 
-include Dnsruby
 class TestRrTest < Minitest::Test
+
+  include Dnsruby
+
   # Stimulus, expected response, and test name:
 
   TESTLIST =	[

--- a/test/tc_rr-unknown.rb
+++ b/test/tc_rr-unknown.rb
@@ -16,8 +16,10 @@
 
 require_relative 'spec_helper'
 
-include Dnsruby
 class TestRrUnknown < Minitest::Test
+
+  include Dnsruby
+
   def test_RrUnknown
     assert_equal(10226, Types::typesbyname('TYPE10226'), 'typesbyname(TYPE10226) returns 10226')
     assert_equal('TYPE10226', Types::typesbyval(10226),        'typesbyval(10226) returns TYPE10226')

--- a/test/tc_rr.rb
+++ b/test/tc_rr.rb
@@ -16,8 +16,10 @@
 
 require_relative 'spec_helper'
 
-include Dnsruby
 class TestRR < Minitest::Test
+
+  include Dnsruby
+
   def test_rr
     # ------------------------------------------------------------------------------
     #  Canned data.

--- a/test/tc_single_resolver.rb
+++ b/test/tc_single_resolver.rb
@@ -16,8 +16,10 @@
 
 require_relative 'spec_helper'
 
-include Dnsruby
 class TestSingleResolver < Minitest::Test
+
+  include Dnsruby
+
   Thread::abort_on_exception = true
   #   Dnsruby.log.level=Logger::DEBUG
 

--- a/test/tc_soak.rb
+++ b/test/tc_soak.rb
@@ -20,7 +20,6 @@ require_relative 'spec_helper'
 require_relative 'tc_soak_base'
 require_relative 'test_dnsserver'
 
-include Dnsruby
 
 # This class tries to soak test the Dnsruby library.
 # It can't do this very well, owing to the small number of sockets allowed to be open simultaneously.
@@ -29,6 +28,8 @@ include Dnsruby
 # @todo@ A test DNS server running on localhost is really needed here
 
 class MyServer < RubyDNS::Server
+
+  include Dnsruby
 
   IP   = "127.0.0.1"
   PORT = 53927

--- a/test/tc_soak_base.rb
+++ b/test/tc_soak_base.rb
@@ -17,7 +17,9 @@
 require_relative 'spec_helper'
 
 class TestSoakBase # < Minitest::Test
+
   include Dnsruby
+
   Rrs = [
   {
     :type       => Types.A,

--- a/test/tc_sshfp.rb
+++ b/test/tc_sshfp.rb
@@ -17,8 +17,10 @@
 
 require_relative 'spec_helper'
 
-include Dnsruby
 class TestSSHFP < Minitest::Test
+
+  include Dnsruby
+
   def test_sshfp
     txt = "apt-blade6.nominet.org.uk. 85826 IN	SSHFP	1 1 6D4CF7C68E3A959990855099E15D6E0D4DEA4FFF"
     sshfp = RR.create(txt)

--- a/test/tc_tsig.rb
+++ b/test/tc_tsig.rb
@@ -17,8 +17,10 @@
 require_relative 'spec_helper'
 
 require "digest/md5"
-include Dnsruby
 class TestTSig < Minitest::Test
+
+  include Dnsruby
+
   KEY_NAME="rubytsig"
   KEY = "8n6gugn4aJ7MazyNlMccGKH1WxD2B3UvN/O/RA6iBupO2/03u9CTa3Ewz3gBWTSBCH3crY4Kk+tigNdeJBAvrw=="
   def is_empty(string)

--- a/test/tc_update.rb
+++ b/test/tc_update.rb
@@ -16,8 +16,10 @@
 
 require_relative 'spec_helper'
 
-include Dnsruby
 class TestUpdate < Minitest::Test
+
+  include Dnsruby
+
   def is_empty(string)
     return true if string == nil || string.length == 0
 

--- a/test/tc_validator.rb
+++ b/test/tc_validator.rb
@@ -16,9 +16,10 @@
 
 require_relative 'spec_helper'
 
-include Dnsruby
-
 class TestValidator < Minitest::Test
+
+  include Dnsruby
+
   def test_validation
 #    Dnsruby::TheLog.level = Logger::DEBUG
     Dnsruby::Dnssec.clear_trusted_keys

--- a/test/tc_zone_reader.rb
+++ b/test/tc_zone_reader.rb
@@ -1,9 +1,9 @@
 
 require_relative 'spec_helper'
 
-include Dnsruby
-
 class ZoneReaderTest < Minitest::Test
+
+  include Dnsruby
 
   def setup
     @zone_data = <<ZONEDATA

--- a/test/ts_online.rb
+++ b/test/ts_online.rb
@@ -59,6 +59,11 @@ if online?
       res_config
   )
 
+  # online_tests = %w(
+  #     resolv
+  #     tcp_pipelining
+  # )
+
   # Excluded are:
   #
   # inet6

--- a/test/ts_online.rb
+++ b/test/ts_online.rb
@@ -52,13 +52,11 @@ if online?
       resolver
       tcp
       tcp_pipelining
-
-  single_resolver
-  cache
-  dns
-  rr-opt
-  res_config
-
+      single_resolver
+      cache
+      dns
+      rr-opt
+      res_config
   )
 
   # Excluded are:


### PR DESCRIPTION
Addresses https://github.com/alexdalitz/dnsruby/issues/113.

As I was troubleshooting another issue I noticed that the includes were outside of class definitions and thought that might be causing a problem, so I moved them.  That turned out not to be the problem but I think incorporating these changes into the code base would be constructive.