### PR TITLE
Remove fixnum and bignum

### DIFF
--- a/lib/dnsruby/bit_mapping.rb
+++ b/lib/dnsruby/bit_mapping.rb
@@ -120,7 +120,7 @@ module Dnsruby
     def assert_non_negative(number)
       unless number.is_a?(Integer) && number >= 0
         raise ArgumentError.new(
-                  "Parameter must be a nonnegative Integer (Fixnum, Bignum) " +
+                  "Parameter must be a nonnegative Integer " +
                       "but is #{number.inspect} (a #{number.class})")
       end
     end

--- a/lib/dnsruby/code_mapper.rb
+++ b/lib/dnsruby/code_mapper.rb
@@ -103,7 +103,7 @@ module Dnsruby
         else
           unknown_string(arg)
         end
-      elsif (arg.kind_of?Fixnum)
+      elsif arg.kind_of?(Integer)
         if (array.values[arg] != nil)
           @code = arg
           @string = array.values[@code]
@@ -146,7 +146,7 @@ module Dnsruby
     end
 
     def CodeMapper.to_code(arg)
-      if (arg.kind_of?Fixnum)
+      if arg.kind_of?(Integer)
         return arg
       else
         return @@arrays[self].stringsdown[arg.downcase]
@@ -154,7 +154,7 @@ module Dnsruby
     end
 
     def <=>(other)
-      if (other.class == Fixnum)
+      if other.is_a?(Integer
         self.code <=> other
       else
         self.code <=> other.code

--- a/lib/dnsruby/code_mapper.rb
+++ b/lib/dnsruby/code_mapper.rb
@@ -154,7 +154,7 @@ module Dnsruby
     end
 
     def <=>(other)
-      if other.is_a?(Integer
+      if other.is_a?(Integer)
         self.code <=> other
       else
         self.code <=> other.code

--- a/lib/dnsruby/config.rb
+++ b/lib/dnsruby/config.rb
@@ -73,7 +73,7 @@ module Dnsruby
     #         nameserver (String)
     #         domain (String)
     #         search (String)
-    #         ndots (Fixnum)
+    #         ndots (Integer)
     # 
     #  This method should not normally be called by client code.
     def set_config_info(config_info)

--- a/lib/dnsruby/packet_sender.rb
+++ b/lib/dnsruby/packet_sender.rb
@@ -544,7 +544,7 @@ module Dnsruby
     end
 
     #  The source port to send queries from
-    #  Returns either a single Fixnum or an Array
+    #  Returns either a single Integer or an Array
     #  e.g. "0", or "[60001, 60002, 60007]"
     # 
     #  Defaults to 0 - random port
@@ -555,7 +555,7 @@ module Dnsruby
       return @src_port
     end
 
-    #  Can be a single Fixnum or a Range or an Array
+    #  Can be a single Integer or a Range or an Array
     #  If an invalid port is selected (one reserved by
     #  IANA), then an ArgumentError will be raised.
     # 
@@ -568,7 +568,7 @@ module Dnsruby
       add_src_port(p)
     end
 
-    #  Can be a single Fixnum or a Range or an Array
+    #  Can be a single Integer or a Range or an Array
     #  If an invalid port is selected (one reserved by
     #  IANA), then an ArgumentError will be raised.
     #  "0" means "any valid port" - this is only a viable

--- a/lib/dnsruby/resolver.rb
+++ b/lib/dnsruby/resolver.rb
@@ -603,7 +603,7 @@ module Dnsruby
     end
 
     #  The source port to send queries from
-    #  Returns either a single Fixnum or an Array
+    #  Returns either a single Integer or an Array
     #  e.g. '0', or '[60001, 60002, 60007]'
     #
     #  Defaults to 0 - random port
@@ -611,7 +611,7 @@ module Dnsruby
       @src_port.length == 1 ? @src_port[0] : @src_port
     end
 
-    #  Can be a single Fixnum or a Range or an Array
+    #  Can be a single Integer or a Range or an Array
     #  If an invalid port is selected (one reserved by
     #  IANA), then an ArgumentError will be raised.
     #
@@ -626,7 +626,7 @@ module Dnsruby
       end
     end
 
-    #  Can be a single Fixnum or a Range or an Array
+    #  Can be a single Integer or a Range or an Array
     #  If an invalid port is selected (one reserved by
     #  IANA), then an ArgumentError will be raised.
     #  "0" means "any valid port" - this is only a viable
@@ -653,7 +653,7 @@ module Dnsruby
     end
 
     def Resolver.check_port(p, src_port=[])
-      if p.class != Fixnum
+      unless p.is_a?(Integer)
         tmp_src_ports = Array.new(src_port)
         p.each do |x|
           unless Resolver.check_port(x, tmp_src_ports)
@@ -677,7 +677,7 @@ module Dnsruby
 
     def Resolver.get_ports_from(p)
       a = []
-      if p.class == Fixnum
+      if p.is_a?(Integer)
         a = [p]
       else
         p.each do |x|

--- a/lib/dnsruby/resource/OPT.rb
+++ b/lib/dnsruby/resource/OPT.rb
@@ -148,7 +148,7 @@ module Dnsruby
       def options(args)
         if (args==nil)
           return @options
-        elsif args.kind_of?Fixnum
+        elsif args.kind_of?(Integer)
           #  return list of options with that code
           ret = []
           @options.each do |option|

--- a/lib/dnsruby/resource/RRSIG.rb
+++ b/lib/dnsruby/resource/RRSIG.rb
@@ -181,7 +181,7 @@ module Dnsruby
       end
 
       def RRSIG.get_time(input)
-        if (input.kind_of?Fixnum)
+        if input.kind_of?(Integer)
           return input
         end
         #  RFC 4034, section 3.2


### PR DESCRIPTION
Fix for https://github.com/alexdalitz/dnsruby/issues/115.

Changed Fixnum references to Integer for compatibility with Ruby >= 2.4.