### PR TITLE
Fix issue #112 by removing a top level `include Dnsruby`

### DIFF
--- a/test/tc_hs.rb
+++ b/test/tc_hs.rb
@@ -1,7 +1,5 @@
 require_relative 'spec_helper'
 
-include Dnsruby
-
 class TestDNS < Minitest::Test
 
   def setup

--- a/test/ts_online.rb
+++ b/test/ts_online.rb
@@ -59,10 +59,6 @@ if online?
       res_config
   )
 
-  # online_tests = %w(
-  #     resolv
-  #     tcp_pipelining
-  # )
 
   # Excluded are:
   #


### PR DESCRIPTION
As described in issue: https://github.com/alexdalitz/dnsruby/issues/112
