### PR TITLE
Updated rubydns gem used for testing

### DIFF
--- a/dnsruby.gemspec
+++ b/dnsruby.gemspec
@@ -33,7 +33,7 @@ DNSSEC NSEC3 support.'
 
   s.add_development_dependency 'rake', '~> 10', '>= 10.3.2'
   s.add_development_dependency 'minitest', '~> 5.4'
-  s.add_development_dependency 'rubydns', '~> 1.0'
+  s.add_development_dependency 'rubydns', '2.0.0.pre.rc1'
   s.add_development_dependency 'nio4r', '~> 1.1'
   s.add_development_dependency 'minitest-display', '>= 0.3.0'
 

--- a/dnsruby.gemspec
+++ b/dnsruby.gemspec
@@ -33,8 +33,8 @@ DNSSEC NSEC3 support.'
 
   s.add_development_dependency 'rake', '~> 10', '>= 10.3.2'
   s.add_development_dependency 'minitest', '~> 5.4'
-  s.add_development_dependency 'rubydns', '2.0.0.pre.rc1'
-  s.add_development_dependency 'nio4r', '~> 2.0'
+  s.add_development_dependency 'rubydns', '2.0.1'
+  s.add_development_dependency 'nio4r', '>= 2.0'
   s.add_development_dependency 'minitest-display', '>= 0.3.0'
 
   if RUBY_VERSION >= "1.9.3"

--- a/dnsruby.gemspec
+++ b/dnsruby.gemspec
@@ -34,7 +34,7 @@ DNSSEC NSEC3 support.'
   s.add_development_dependency 'rake', '~> 10', '>= 10.3.2'
   s.add_development_dependency 'minitest', '~> 5.4'
   s.add_development_dependency 'rubydns', '2.0.0.pre.rc1'
-  s.add_development_dependency 'nio4r', '~> 1.1'
+  s.add_development_dependency 'nio4r', '~> 2.0'
   s.add_development_dependency 'minitest-display', '>= 0.3.0'
 
   if RUBY_VERSION >= "1.9.3"

--- a/test/localdns.rb
+++ b/test/localdns.rb
@@ -1,0 +1,29 @@
+#!/usr/bin/env ruby
+
+require_relative 'spec_helper'
+
+require_relative "test_dnsserver"
+
+class SimpleTCPPipeliningUDPServer < Async::DNS::Server
+  PORT     = 53938
+  IP   = '127.0.0.1'
+
+  def initialize(**options)
+    super(options)
+
+    @handlers << TcpPipelineHandler.new(self, IP, PORT)
+    @handlers << Async::DNS::UDPServerHandler.new(self, IP, PORT)
+
+  end
+
+  def process(name, resource_class, transaction)
+    @logger.debug "name: #{name}"
+    transaction.respond!("93.184.216.34", { resource_class: ::Resolv::DNS::Resource::IN::A })
+  end
+
+end
+
+
+if __FILE__ == $0
+  RubyDNS::run_server(server_class: SimpleTCPPipeliningUDPServer)
+end

--- a/test/tc_soak.rb
+++ b/test/tc_soak.rb
@@ -19,72 +19,35 @@ require_relative 'spec_helper'
 # require_relative 'tc_single_resolver'
 require_relative 'tc_soak_base'
 require_relative 'test_dnsserver'
+require_relative 'localdns'
 
 
 # This class tries to soak test the Dnsruby library.
 # It can't do this very well, owing to the small number of sockets allowed to be open simultaneously.
 # @TODO@ Future versions of dnsruby will allow random streaming over a fixed number of (cycling) random sockets,
 # so this test can be beefed up considerably at that point.
-# @todo@ A test DNS server running on localhost is really needed here
-
-class MyServer < RubyDNS::Server
-
-  include Dnsruby
-
-  IP   = "127.0.0.1"
-  PORT = 53927
-
-  @@stats = Stats.new
-
-  def self.stats
-    @@stats
-  end
-
-  def process(name, resource_class, transaction)
-    transaction.respond!("93.184.216.34", { resource_class: Resolv::DNS::Resource::IN::A })
-    Celluloid.logger.debug "got message"
-  end
-end
-
-class PipeliningServer < MyServer
-  def run
-    fire(:setup)
-
-    link NioTcpPipeliningHandler.new(self, IP, PORT, 5) #5 max request
-    link RubyDNS::UDPHandler.new(self, IP, PORT)
-
-    fire(:start)
-  end
-end
 
 class TestSingleResolverSoak < Minitest::Test
 
-  IP   = MyServer::IP
-  PORT = MyServer::PORT
+  IP   = SimpleTCPPipeliningUDPServer::IP
+  PORT = SimpleTCPPipeliningUDPServer::PORT
 
   def initialize(arg)
     super(arg)
-    self.class.init
-  end
-
-  def self.init
-    unless @initialized
-      Celluloid.boot
-      # By default, Celluloid logs output to console. Use Dnsruby.log instead.
-      Celluloid.logger = Dnsruby.log
-      @initialized = true
-    end
   end
 
   SINGLE_RESOLVER_QUERY_TIMES = 63
 
   def setup
-    # Instantiate a new server
-    # For each query respond with 93.184.216.34
+    # Instantiate a local dns server
+    pipe = IO.popen("./test/localdns.rb")
+    @dnspid = pipe.pid
+    sleep 1
+  end
 
-    @@supervisor ||= RubyDNS::run_server(asynchronous: true,
-                                         server_class: PipeliningServer)
-
+  def teardown
+    Process.kill("KILL", @dnspid)
+    sleep 1
   end
 
   def test_many_asynchronous_queries_one_single_resolver
@@ -115,14 +78,14 @@ class TestSingleResolverSoak < Minitest::Test
     q = Queue.new
     timeout_count = 0
     resolvers = Array.new(num_resolvers) do
-      SingleResolver.new(server:                     IP,
-                         port:                       PORT,
-                         do_caching:                 false,
-                         do_validation:              false,
-                         tcp_pipelining:             pipelining,
-                         packet_timeout:             10,
-                         tcp_pipelining_max_queries: 5,
-                         use_tcp:                    tcp)
+      Dnsruby::SingleResolver.new(server:                     IP,
+                                  port:                       PORT,
+                                  do_caching:                 false,
+                                  do_validation:              false,
+                                  tcp_pipelining:             pipelining,
+                                  packet_timeout:             10,
+                                  tcp_pipelining_max_queries: 5,
+                                  use_tcp:                    tcp)
     end
     start = Time.now
 
@@ -130,7 +93,7 @@ class TestSingleResolverSoak < Minitest::Test
     #  this test while we're not using single sockets.
     #  We run four queries per iteration, so we're limited to 64 runs.
     messages = TestSoakBase::Rrs.map do |data|
-      message = Message.new(data[:name], data[:type])
+      message = Dnsruby::Message.new(data[:name], data[:type])
       message.do_validation = false
       message.do_caching    = false
       message
@@ -141,9 +104,9 @@ class TestSingleResolverSoak < Minitest::Test
     receive_thread = Thread.new do
       query_count.times do
         _id, ret, error = q.pop
-        if error.is_a?(ResolvTimeout)
+        if error.is_a?(Dnsruby::ResolvTimeout)
           timeout_count+=1
-        elsif ret.class != Message
+        elsif ret.class != Dnsruby::Message
           p "ERROR RETURNED : #{error}"
         end
       end
@@ -193,7 +156,7 @@ class TestSingleResolverSoak < Minitest::Test
             packet=nil
             begin
               packet = res.query(data[:name], data[:type])
-            rescue ResolvTimeout
+            rescue Dnsruby::ResolvTimeout
               mutex.synchronize { timeout_count += 1 }
               next
             end
@@ -248,19 +211,19 @@ class TestSingleResolverSoak < Minitest::Test
             end
             q = Queue.new
 
-            message = Message.new(data[:name], data[:type])
+            message = Dnsruby::Message.new(data[:name], data[:type])
             message.do_validation = false
             message.do_caching    = false
 
             res.send_async(message, q, [i,j])
 
             id, packet, error = q.pop
-            if (error.class == ResolvTimeout)
+            if (error.class == Dnsruby::ResolvTimeout)
               mutex.synchronize {
                 timeout_count+=1
               }
               next
-            elsif (packet.class!=Message)
+            elsif (packet.class!=Dnsruby::Message)
               puts "ERROR! #{error}"
             end
 
@@ -278,13 +241,12 @@ class TestSingleResolverSoak < Minitest::Test
     assert(timeout_count < query_count * 0.1, "#{timeout_count} of #{query_count} timed out!")
   end
 
-
   def create_default_single_resolver
-    SingleResolver.new(server:         IP,
-                       port:           PORT,
-                       do_caching:     false,
-                       do_validation:  false,
-                       packet_timeout: 10)
+    Dnsruby::SingleResolver.new(server:         IP,
+                                port:           PORT,
+                                do_caching:     false,
+                                do_validation:  false,
+                                packet_timeout: 10)
 
   end
 end


### PR DESCRIPTION
Using a local dns (based on rubydns as a separate process) during the soak test

All changes are under the test directory so it's minimal impact.
There was a bit a rework needed due to the rubydns update. The gem was split in 3 (async, async-dns, rubydns). I tried my best to use the new gems accordingly.

The local dns change should simplify soak testing. Everything is done internally in 2 different processes (localdns & ruby test process). The soak test instantiates a local dns and then kills it for every test in setup and teardown methods.