### PR TITLE
Fix deletion of TXT records with spaces

### DIFF
--- a/lib/dnsruby/update.rb
+++ b/lib/dnsruby/update.rb
@@ -1,12 +1,12 @@
 # --
 # Copyright 2007 Nominet UK
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,81 +20,81 @@ module Dnsruby
 
   # The first example below shows a complete program; subsequent examples
   # show only the creation of the update packet.
-  # 
+  #
   # == Add a new host
-  # 
+  #
   #  require 'Dnsruby'
-  # 
+  #
   #  # Create the update packet.
   #  update = Dnsruby::Update.new('example.com')
-  # 
+  #
   #  # Prerequisite is that no A records exist for the name.
   #  update.absent('foo.example.com.', 'A')
-  # 
+  #
   #  # Add two A records for the name.
   #  update.add('foo.example.com.', 'A', 86400, '192.168.1.2')
   #  update.add('foo.example.com.', 'A', 86400, '172.16.3.4')
-  # 
+  #
   #  # Send the update to the zone's primary master.
   #  res = Dnsruby::Resolver.new({:nameserver => 'primary-master.example.com'})
-  # 
+  #
   #  begin
   #      reply = res.send_message(update)
   #      print "Update succeeded\n"
   #   rescue Exception => e
   #      print 'Update failed: #{e}\n'
   #   end
-  # 
+  #
   # == Add an MX record for a name that already exists
-  # 
+  #
   #     update = Dnsruby::Update.new('example.com')
   #     update.present('example.com')
   #     update.add('example.com', Dnsruby::Types.MX, 86400, 10, 'mailhost.example.com')
-  # 
+  #
   # == Add a TXT record for a name that doesn't exist
-  # 
+  #
   #     update = Dnsruby::Update.new('example.com')
   #     update.absent('info.example.com')
   #     update.add('info.example.com', Types.TXT, 86400, "yabba dabba doo"')
-  # 
+  #
   # == Delete all A records for a name
-  # 
+  #
   #     update = Dnsruby::Update.new('example.com')
   #     update.present('foo.example.com', 'A')
   #     update.delete('foo.example.com', 'A')
-  # 
+  #
   # == Delete all RRs for a name
-  # 
+  #
   #     update = Dnsruby::Update.new('example.com')
   #     update.present('byebye.example.com')
   #     update.delete('byebye.example.com')
-  # 
+  #
   # == Perform a signed update
-  # 
+  #
   #     key_name = 'tsig-key'
   #     key      = 'awwLOtRfpGE+rRKF2+DEiw=='
-  # 
+  #
   #     update = Dnsruby::Update.new('example.com')
   #     update.add('foo.example.com', 'A', 86400, '10.1.2.3'))
   #     update.add('bar.example.com', 'A', 86400, '10.4.5.6'))
   #     res.tsig=(key_name,key)
-  # 
+  #
   class Update < Message
     # Returns a Dnsruby::Update object suitable for performing a DNS
     # dynamic update.  Specifically, it creates a message with the header
     # opcode set to UPDATE and the zone record type to SOA (per RFC 2136,
     # Section 2.3).
-    # 
+    #
     # Programs must use the push method to add RRs to the prerequisite,
     # update, and additional sections before performing the update.
-    # 
+    #
     # Arguments are the zone name and the class.  If the zone is omitted,
     # the default domain will be taken from the resolver configuration.
     # If the class is omitted, it defaults to IN.
     #     packet = Dnsruby::Update.new
     #     packet = Dnsruby::Update.new('example.com')
     #     packet = Dnsruby::Update.new('example.com', 'HS')
-    # 
+    #
     def initialize(zone=nil, klass=nil)
 
       #  sort out the zone section (RFC2136, section 2.3)
@@ -115,25 +115,25 @@ module Dnsruby
     end
 
     # Ways to create the prerequisite records (exists, notexists, inuse, etc. - RFC2136, section 2.4)
-    # 
+    #
     #       (1)  RRset exists (value independent).  At least one RR with a
     #            specified NAME and TYPE (in the zone and class specified by
     #            the Zone Section) must exist.
-    # 
+    #
     #            update.present(name, type)
-    # 
+    #
     #       (2)  RRset exists (value dependent).  A set of RRs with a
     #            specified NAME and TYPE exists and has the same members
     #            with the same RDATAs as the RRset specified here in this
     #            Section.
-    # 
+    #
     #            update.present(name, type, rdata)
-    # 
+    #
     #       (4)  Name is in use.  At least one RR with a specified NAME (in
     #            the zone and class specified by the Zone Section) must exist.
     #            Note that this prerequisite is NOT satisfied by empty
     #            nonterminals.
-    # 
+    #
     #            update.present(name)
     def present(*args)
       ttl = 0
@@ -159,18 +159,18 @@ module Dnsruby
 
     # Ways to create the prerequisite records (exists, notexists, inuse, etc. - RFC2136, section 2.4)
     # Can be called with one arg :
-    # 
+    #
     #    update.absent(name)
     #       (5)  Name is not in use.  No RR of any type is owned by a
     #            specified NAME.  Note that this prerequisite IS satisfied by
     #            empty nonterminals.
-    # 
+    #
     # Or with two :
-    # 
+    #
     #    update.absent(name, type)
     #       (3)  RRset does not exist.  No RRs with a specified NAME and TYPE
     #           (in the zone and class denoted by the Zone Section) can exist.
-    # 
+    #
     def absent(*args)
       ttl = 0
       rdata = ""
@@ -191,16 +191,16 @@ module Dnsruby
 
     # Ways to create the update records (add, delete, RFC2136, section 2.5)
     #   " 2.5.1 - Add To An RRset
-    # 
+    #
     #    RRs are added to the Update Section whose NAME, TYPE, TTL, RDLENGTH
     #    and RDATA are those being added, and CLASS is the same as the zone
     #    class.  Any duplicate RRs will be silently ignored by the primary
     #    master."
-    # 
+    #
     #    update.add(rr)
     #    update.add([rr1, rr2])
     #    update.add(name, type, ttl, rdata)
-    # 
+    #
     def add(*args)
       zoneclass=zone()[0].zclass
       case args[0]
@@ -244,17 +244,17 @@ module Dnsruby
     end
 
     # Ways to create the update records (add, delete, RFC2136, section 2.5)
-    # 
+    #
     # 2.5.2 - Delete An RRset
     #    update.delete(name, type)
-    # 
-    # 
+    #
+    #
     # 2.5.3 - Delete All RRsets From A Name
     #    update.delete(name)
-    # 
+    #
     # 2.5.4 - Delete An RR From An RRset
     #   update.delete(name, type, rdata)
-    # 
+    #
     def delete(*args)
       ttl = 0
       klass = Classes.ANY
@@ -268,7 +268,24 @@ module Dnsruby
         resource = RR.create("#{args[0]} #{ttl} #{klass} #{args[1]} #{rdata}")
         add_update(resource)
       when 3 # name, type, rdata
-        resource = RR.create("#{args[0]} #{ttl} IN #{args[1]} #{args[2]}")
+        name = args[0]
+        type = args[1]
+        rdata = args[2]
+        if (Types.new(type) == Types.TXT)
+          instring = "#{name} #{ttl} IN #{type} ";
+          if (String === rdata)
+            instring += " '#{rdata}'"
+          elsif (Array === rdata)
+            rdata.length.times {|rcounter|
+            instring += " '#{rdata[rcounter]}' "
+            }
+          else
+            instring += rdata
+          end
+          resource = RR.create(instring)
+        else
+          resource = RR.create("#{name} #{ttl} IN #{type} #{rdata}")
+        end
         resource.klass = Classes.NONE
         add_update(resource)
       end

--- a/test/tc_update.rb
+++ b/test/tc_update.rb
@@ -274,6 +274,18 @@ class TestUpdate < Minitest::Test
     assert(update.to_s.index("test signed update"))
   end
 
+  def test_delete_txt
+    update = Update.new 'example.com'
+    update.delete 'test.example.com', 'TXT', 'foo bar'
+
+    encoded_msg = Message.decode update.encode
+    rr = encoded_msg.authority.first
+    assert_equal rr.name.to_s, 'test.example.com', 'delete_txt - right name'
+    assert_equal 0, rr.ttl, 'delete_txt - right ttl'
+    assert_equal 'TXT', rr.type.string, 'delete_txt - right type'
+    assert_equal ['foo bar'], rr.rdata, 'delete_txt - right rdata'
+  end
+
   def test_array
     update = Update.new
     update.add("target_name", "TXT", 100, ['"test signed update"', 'item#2'])


### PR DESCRIPTION
This patch allows for spaces in strings as well as arrays when deleting TXT records.  This makes it match what's allowed for adding a TXT record.