### PR TITLE
Fix use of non-default ports in Dnsruby::Resolver

### DIFF
--- a/lib/dnsruby/resolver.rb
+++ b/lib/dnsruby/resolver.rb
@@ -487,6 +487,7 @@ module Dnsruby
         @config.nameserver.each do |ns|
           res = PacketSender.new({
               server:             ns,
+              port:               @port,
               dnssec:             @dnssec,
               use_tcp:            @use_tcp,
               no_tcp:             @no_tcp,


### PR DESCRIPTION
Tiny patch to pass `@port` through from Dnsruby::Resolver to the PacketSender(s).