### PR TITLE
avoid changing global thread abort behavior

### DIFF
--- a/lib/dnsruby/select_thread.rb
+++ b/lib/dnsruby/select_thread.rb
@@ -24,7 +24,6 @@ require 'set'
 require 'singleton'
 require 'dnsruby/validator_thread.rb'
 module Dnsruby
-  Thread::abort_on_exception = true
   class SelectThread #:nodoc: all
     class SelectWakeup < RuntimeError; end
     include Singleton


### PR DESCRIPTION
It appears that a side-effect of requiring this library changes the global behavior of threads across the entire program. We noticed this while testing dnsruby in a Metasploit module. Is it sufficient just to remove this global change in behavior, or is this actually needed by dnsruby?