### PR TITLE
don't depend on git to identify files in this gem

### DIFF
--- a/dnsruby.gemspec
+++ b/dnsruby.gemspec
@@ -1,6 +1,7 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'dnsruby/version'
+require 'rake'
 
 SPEC = Gem::Specification.new do |s|
   s.name = "dnsruby"
@@ -15,7 +16,7 @@ SPEC = Gem::Specification.new do |s|
 stub resolver. It aims to comply with all DNS RFCs, including
 DNSSEC NSEC3 support.'
   s.license = "Apache License, Version 2.0"
-  s.files = `git ls-files -z`.split("\x0")
+  s.files = FileList['**/*.*'].exclude('*.gem*')
 
   s.post_install_message = \
 "Installing dnsruby...


### PR DESCRIPTION
This popped up from Kali Linux users using Metasploit who noticed a random git
error message with the latest HEAD version of this gem. We traced it back to git
being used unconditionally by this gem in the gemspec file. This changes to
prefer rake's file glob method instead, which removes the dependency on the
.git directory existing.

See https://github.com/rapid7/metasploit-framework/issues/8808 for background.