### PR TITLE
README: add CAA to list of records supported by this library

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ queries. It is therefore suitable for high volume DNS applications.
 
 The following is a (non-exhaustive) list of features :
 
-- Implemented RRs :  A, AAAA, AFSDB, ANY, CERT, CNAME, DNAME, GPOS,
-     HINFO, ISDN, LOC, MB, MG, MINFO, MR, MX, NAPTR, NS, NSAP, NXT,
-     OPT, PTR, PX, RP, RT, SOA, SPF, SRV, TKEY, TSIG, TXT, WKS,
-     X25, DNSKEY, RRSIG, NSEC, NSEC3, NSEC3PARAM, DS, DLV
+- Implemented RRs :  A, AAAA, AFSDB, ANY, CAA, CERT, CNAME, DNAME,
+     GPOS, HINFO, ISDN, LOC, MB, MG, MINFO, MR, MX, NAPTR, NS, NSAP,
+     NXT, OPT, PTR, PX, RP, RT, SOA, SPF, SRV, TKEY, TSIG, TXT,
+     WKS, X25, DNSKEY, RRSIG, NSEC, NSEC3, NSEC3PARAM, DS, DLV
 
 - Generic RR types supported (RFC3597)
 


### PR DESCRIPTION
Supported since v0.60.1: https://github.com/alexdalitz/dnsruby/blob/master/RELEASE_NOTES.md#v1601

/cc @alexdalitz 