### PR TITLE
`has_rdoc=` is deprecated with no replacement

### DIFF
--- a/dnsruby.gemspec
+++ b/dnsruby.gemspec
@@ -23,7 +23,6 @@ DNSSEC NSEC3 support.'
   For general discussion (please tell us how you use dnsruby): https://groups.google.com/forum/#!forum/dnsruby"
 
   s.test_file = "test/ts_offline.rb"
-  s.has_rdoc = true
   s.extra_rdoc_files = ["DNSSEC", "EXAMPLES", "README.md", "EVENTMACHINE"]
 
   unless /java/ === RUBY_PLATFORM


### PR DESCRIPTION
Resolve the following deprecation warning.

```
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /Users/kenchan/src/github.com/alexdalitz/dnsruby/dnsruby.gemspec:26.
```