### PR TITLE
Use default port (53) in Dnsruby::DNS when :port is nil

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,6 +22,7 @@ def create_task(task_name, test_suite_filespec)
     t.name = task_name
     t.test_files = FileList[test_suite_filespec]
     t.verbose = true
+    t.warning = false
   end
 end
 

--- a/lib/dnsruby/config.rb
+++ b/lib/dnsruby/config.rb
@@ -38,6 +38,7 @@ module Dnsruby
   #  a query is performed (or a config parameter requested on) a Resolver which has
   #  not yet been configured.
   class Config
+    DEFAULT_PORT = 53
     # --
     # @TODO@ Switches for :
     # 
@@ -101,7 +102,7 @@ module Dnsruby
         dom=""
         nd = 1
         @ndots = 1
-        @port = 53
+        @port = DEFAULT_PORT
         @apply_search_list = true
         @apply_domain = true
         config_hash = Config.default_config_hash
@@ -165,7 +166,7 @@ module Dnsruby
     #  Set port
     def port=(p)
       @configured = true
-      @port=p
+      @port=p if p
       if !@port.kind_of?(Integer)
         raise ArgumentError.new("invalid port config: #{@port.inspect}")
       end
@@ -315,7 +316,7 @@ module Dnsruby
       search = nil
       domain = nil
       ndots = 1
-      port = 53
+      port = DEFAULT_PORT
       open(filename) {|f|
         f.each {|line|
           line.sub!(/[#;].*/, '')

--- a/test/tc_dns.rb
+++ b/test/tc_dns.rb
@@ -86,8 +86,8 @@ class TestDNS < Minitest::Test
     # 
     Dnsruby.log.level=Logger::FATAL
     [:nameserver].each do |test|
-#      [{}, 'kjghdfkjhase',1,'\1',nil].each do |input|
-# Config now only checks that an IPv4, IPv6 or Name can be made with each input
+      # [{}, 'kjghdfkjhase',1,'\1',nil].each do |input|
+      # Config now only checks that an IPv4, IPv6 or Name can be made with each input
       [{},1,nil].each do |input|
         res=nil
         begin
@@ -247,11 +247,16 @@ class TestDNS < Minitest::Test
       assert_equal(a[0].name.to_s, 'a.t.net-dns.org',"Correct name (with persistent socket and #{method})")
       # assert_equal(a[0].name.to_s, 'a.t.dnsruby.validation-test-servers.nominet.org.uk',"Correct name (with persistent socket and #{method})")
     end
-
-    def test_port
-      d = DNS.new({:port => 5353})
-      assert_true(d.to_s.include?"5353")
-    end
-
   end
+
+  def test_port
+    d = DNS.new({:port => 5353})
+    assert(d.to_s.include?"5353")
+  end
+
+  def test_port_nil
+    d = DNS.new({:port => nil})
+    assert(d.to_s.include? Dnsruby::Config::DEFAULT_PORT.to_s)
+  end
+
 end

--- a/test/tc_resolv.rb
+++ b/test/tc_resolv.rb
@@ -21,6 +21,7 @@ class TestResolv < Minitest::Test
 
   RELATIVE_NAME = 'google-public-dns-a.google.com'
   ABSOLUTE_NAME = RELATIVE_NAME + '.'
+  IPV4_NAME     = 'dns.google'
   IPV4_ADDR     = '8.8.8.8'
   IPV6_ADDR     = '2001:4860:4860::8888'
   ADDRESSES     = [IPV4_ADDR, IPV6_ADDR]
@@ -52,8 +53,7 @@ class TestResolv < Minitest::Test
 
 
   def test_resolv_address_to_name
-
-    assert_equal(RELATIVE_NAME, Dnsruby::Resolv.getname(IPV4_ADDR).to_s)
+    assert_equal(IPV4_NAME, Dnsruby::Resolv.getname(IPV4_ADDR).to_s)
 
     assert_raises(Dnsruby::ResolvError) do
       Dnsruby::Resolv.getname(RELATIVE_NAME)
@@ -61,8 +61,8 @@ class TestResolv < Minitest::Test
 
     names = Dnsruby::Resolv.getnames(IPV4_ADDR)
     assert_equal(1, names.size)
-    assert_equal(RELATIVE_NAME, names.first.to_s)
-    Dnsruby::Resolv.each_name(IPV4_ADDR) { |name| assert_equal(RELATIVE_NAME, name.to_s)}
+    assert_equal(IPV4_NAME, names.first.to_s)
+    Dnsruby::Resolv.each_name(IPV4_ADDR) { |name| assert_equal(IPV4_NAME, name.to_s)}
   end
 
   def test_resolv_address_to_address

--- a/test/tc_resolver.rb
+++ b/test/tc_resolver.rb
@@ -138,7 +138,7 @@ class TestResolver < Minitest::Test
     ret.each_answer do |answer|
       if (answer.type==Types.PTR)
         no_pointer=false
-        assert(answer.domainname.to_s=~/google-public-dns/)
+        assert(answer.domainname.to_s =~ /dns.google|google-public-dns/)
       end
     end
     assert(!no_pointer)


### PR DESCRIPTION
This occurs when DNS is initialized with nil such as DNS.new(:port => nil) or when configuration is automatically detected (but there is no network connection so port is nil).

Fixes: https://github.com/alexdalitz/dnsruby/issues/153
ArgumentError (invalid port config: nil) on Dns.new() with no network connection

Also:
- Fixed tc_dns.rb#test_port test, it was nested inside of #test_searchlist and therefore was not actually running
- Added tc_dns.rb#test_port_nil test
- Turned off verbose Rack warnings (using 'rake test' was overrun by inconsequential warnings)
- Fixed tests in tc_resolv.rb and tc_resolver.rb tests - google DNS host name has changed

```
$ rake test
Running online tests. These tests send UDP packets - some may be lost.
If you get the odd timeout error with these tests, try running them again.
It may just be that some UDP packets got lost the first time...
-----------------------------------------------------------------------
OpenSSL not present (with full functionality) - skipping DS digest test
-----------------------------------------------------------------------
Run options: --seed 31421

# Running:


Minitest::Result | ................................................................
                 | ................................................................
                 | ................................................................
                 | ..
                 | 42.55 s
Slowest tests:
6.56 s	Minitest::Result#test_TCP_pipelining_timeout
6.23 s	Minitest::Result#test_TCP_pipelining_timeout_in_send
3.02 s	Minitest::Result#test_cache
3.00 s	Minitest::Result#test_TCP_pipelining_socket_eof
2.86 s	Minitest::Result#test_reverse_lookup
2.58 s	Minitest::Result#test_queue_timeout
Slowest suites:
42.64 s	Minitest::Result

Finished in 42.675147s, 4.5460 runs/s, 40.3045 assertions/s.
194 runs, 1720 assertions, 0 failures, 0 errors, 0 skips
```