### PR TITLE
Fix create name include url special characters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source 'https://rubygems.org'
 
 gemspec
-
-gem "addressable", "~> 2.5"

--- a/dnsruby.gemspec
+++ b/dnsruby.gemspec
@@ -40,7 +40,7 @@ DNSSEC NSEC3 support.'
     'source_code_uri'   => 'https://github.com/alexdalitz/dnsruby',
   }
 
-  s.add_development_dependency 'rake', '~> 10', '>= 12.3.3'
+  s.add_development_dependency 'rake', '>= 12.3.3'
   s.add_development_dependency 'minitest', '~> 5.4'
   s.add_development_dependency 'rubydns', '~> 2.0.1'
   s.add_development_dependency 'nio4r', '~> 2.0'
@@ -51,6 +51,6 @@ DNSSEC NSEC3 support.'
     s.add_development_dependency 'coveralls', '~> 0.7'
   end
 
-  s.add_runtime_dependency 'addressable', '~> 2.5'
+  s.add_runtime_dependency 'simpleidn', '~> 0.16'
 end
 

--- a/dnsruby.gemspec
+++ b/dnsruby.gemspec
@@ -51,6 +51,6 @@ DNSSEC NSEC3 support.'
     s.add_development_dependency 'coveralls', '~> 0.7'
   end
 
-  s.add_runtime_dependency 'simpleidn', '~> 0.16'
+  s.add_runtime_dependency 'simpleidn', '~> 0.1'
 end
 

--- a/lib/dnsruby/name.rb
+++ b/lib/dnsruby/name.rb
@@ -27,7 +27,7 @@ module Dnsruby
   # * Name#subdomain_of?(other)
   # * Name#labels
   #
-  require 'addressable'
+  require 'simpleidn'
   class Name
     include Comparable
     MaxNameLength=255
@@ -70,19 +70,11 @@ module Dnsruby
     #   Dnsruby::Name.punycode('🏳.cf')
     #   => "xn--en8h.cf"
     def self.punycode(d)
-        begin
-          c = Addressable::URI.parse("http://" + d.to_s)
-          ret = c.normalized_host.sub("http://", "")
-          if (!d.end_with?".")
-            return ret.chomp(".")
-          end
-          if (!ret.end_with?".")
-            return ret + "."
-          end
-          return ret
-        rescue Exception => e
-          return d
-        end
+      begin
+        return SimpleIDN.to_ascii(d)
+      rescue
+        return d
+      end
     end
 
     def self.split_escaped(arg) #:nodoc: all

--- a/test/tc_name.rb
+++ b/test/tc_name.rb
@@ -80,4 +80,23 @@ class TestName < Minitest::Test
     n2 = Name.create("nall.all.")
     assert(n1 == n2, n1.to_s)
   end
+
+  def test_punycode
+    [
+      [
+        "møllerriis.com",
+        "xn--mllerriis-l8a.com"
+      ],
+      [
+        "フガフガ。hogehoge.エグザンプル.JP",
+        "xn--mcka5jb.hogehoge.xn--ickqs6k2dyb.jp"
+      ],
+      [
+        "フガ#フガ。hogehoge.エグザンプル.JP",
+        "xn--#-yeub5nc.hogehoge.xn--ickqs6k2dyb.jp"
+      ]
+    ].each do |tc|
+      assert_equal(Dnsruby::Name.create(tc[0]).to_s, tc[1])
+    end
+  end
 end


### PR DESCRIPTION
```
["hoge/hoge","hoge#hoge","hoge?hoge"].each do |d|
  pp "input #{d}"
  pp "output #{Dnsruby::Name.create(d)}"
end
"input hoge/hoge"
"output hoge"
"input hoge#hoge"
"output hoge"
"input hoge?hoge"
"output hoge"
```