### PR TITLE
Implement ECDSAP256SHA256 (13) / ECDSAP384SHA384 (14) algorithms

### DIFF
--- a/lib/dnsruby/validator_thread.rb
+++ b/lib/dnsruby/validator_thread.rb
@@ -1,12 +1,12 @@
 # --
 # Copyright 2007 Nominet UK
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -109,7 +109,7 @@ module Dnsruby
           return true
         rescue VerifyError => e
           response.security_error = e
-          response.security_level = BOGUS
+          response.security_level = Message::SecurityLevel.BOGUS
           #  Response security_level should already be set
           return false
         end

--- a/test/tc_dnskey.rb
+++ b/test/tc_dnskey.rb
@@ -85,4 +85,33 @@ class DnskeyTest < Minitest::Test
     dnskey.protocol=3
 
   end
+
+  def test_ecdsa_integrity
+    ecdsa_256_pub = 'example.com. 3600 IN DNSKEY 256 3 13 ( oJMRESz5E4gYzS/q6XD' +
+    'rvU1qMPYIjCWzJaOau8XNEZeqCYKD5ar0IRd8KqXXFJkqmVfRvMGPmM1x8fGAa2XhSA== )'
+
+    dnskey = Dnsruby::RR.create(ecdsa_256_pub)
+    assert_equal(3, dnskey.protocol)
+    assert_equal(256, dnskey.flags)
+    assert_equal(Dnsruby::Algorithms::ECDSAP256SHA256, dnskey.algorithm)
+    assert_equal(Dnsruby::RR::DNSKEY::ZONE_KEY, dnskey.flags & Dnsruby::RR::DNSKEY::ZONE_KEY)
+    assert_equal(0, dnskey.flags & Dnsruby::RR::DNSKEY::SEP_KEY)
+
+    dnskey2 = Dnsruby::RR.create(dnskey.to_s)
+    assert(dnskey2.to_s == dnskey.to_s, "#{dnskey} not equal to \n#{dnskey2}")
+
+    ecdsa_384_pub = 'example.com. 3600 IN DNSKEY 256 3 14 ( Bl2HDw98sGin4lNlx7n' +
+    'QX3w98jx6UhAgC73Jq+6LFlD12gnVTMHecM8Z GoTFSh+mV+qEPFZ5s3NbC4qvwUW0kkPb+0ip' +
+    'CuLRwZYhYKk7D+RDb+fX XozI9hhZrsXBcEhss )'
+
+    dnskey = Dnsruby::RR.create(ecdsa_384_pub)
+    assert_equal(3, dnskey.protocol)
+    assert_equal(256, dnskey.flags)
+    assert_equal(Dnsruby::Algorithms::ECDSAP384SHA384, dnskey.algorithm)
+    assert_equal(Dnsruby::RR::DNSKEY::ZONE_KEY, dnskey.flags & Dnsruby::RR::DNSKEY::ZONE_KEY)
+    assert_equal(0, dnskey.flags & Dnsruby::RR::DNSKEY::SEP_KEY)
+
+    dnskey2 = Dnsruby::RR.create(dnskey.to_s)
+    assert(dnskey2.to_s == dnskey.to_s, "#{dnskey} not equal to \n#{dnskey2}")
+  end
 end

--- a/test/tc_verifier.rb
+++ b/test/tc_verifier.rb
@@ -31,6 +31,7 @@ class VerifierTest < Minitest::Test
       do_test_sha256
       do_test_sha512
       do_test_nsec
+      do_test_ecdsa256
     else
       print "OpenSSL doesn't support SHA2 - disabling SHA256/SHA512 tests. DNSSEC validation will not work with these type of signatures.\n"
     end
@@ -68,6 +69,20 @@ class VerifierTest < Minitest::Test
     rrset.add(sig)
     verifier = Dnsruby::SingleVerifier.new(nil)
     verifier.verify_rrset(rrset, key512)
+  end
+
+  def do_test_ecdsa256
+    Time.stub :now, Time.parse("Wed, 01 Jul 2020 11:54:04 EEST +03:00") do
+      ecdsa256 = Dnsruby::RR.create("rainiselevi.ee.	3600	IN	DNSKEY	256 3 ECDSAP256SHA256 ( oJMRESz5E
+        4gYzS/q6XDrvU1qMPYIjCWzJaOau8XNEZeqCYKD5ar0IRd8KqXXFJkqmVfRvMGPmM1x8fGAa2XhSA== ) ; key_tag=34505")
+      a = Dnsruby::RR.create("rainiselevi.ee.	3600	IN	A	35.228.30.236")
+      sig = Dnsruby::RR.create("rainiselevi.ee.	3600	IN	RRSIG	A ECDSAP256SHA256 2 300 20200702092142 ( 20200630072142 34505
+         rainiselevi.ee. kf3Fl1mSIso2kB12QOr+aNWYTUXtx9nRC/v+Kn1454u9I/YAFQd6nJQAsFd9vCTsZY+nL4wpj5pV+EsAMIxccA== )")
+      rrset = Dnsruby::RRSet.new(a)
+      rrset.add(sig)
+      verifier = Dnsruby::SingleVerifier.new(nil)
+      assert(verifier.verify_rrset(rrset, ecdsa256))
+    end
   end
 
   def test_se_query


### PR DESCRIPTION
Makes it possible to validate DNSSEC data for algorithms 13 and 14. Has been tested with ECDSAP256SHA256, but alg 14 should follow the same logic.