### PR TITLE
Reinitialize all IANA TAR keys with Dnssec.reset

### DIFF
--- a/lib/dnsruby/dnssec.rb
+++ b/lib/dnsruby/dnssec.rb
@@ -128,6 +128,7 @@ module Dnsruby
       @@validation_policy = ValidationPolicy::LOCAL_ANCHORS_THEN_ROOT
       @@root_verifier = SingleVerifier.new(SingleVerifier::VerifierType::ROOT)
       @@root_verifier.add_root_ds(@@root_key)
+      @@root_verifier.add_root_ds(@@root_key_new)
 
       @@dlv_verifier = SingleVerifier.new(SingleVerifier::VerifierType::DLV)
 


### PR DESCRIPTION
Simple fix to Dnsruby::Dnssec.reset method. Caused some dnssec-enabled domains to report invalid security level after using this method because one of the keys was not reinitialized.