### PR TITLE
Fix Ruby 2.7 deprecation warning in tests

### DIFF
--- a/test/tc_resolver.rb
+++ b/test/tc_resolver.rb
@@ -171,7 +171,7 @@ class TestResolver < Minitest::Test
     # test timeout behaviour for different retry, retrans, total timeout etc.
     # Problem here is that many sockets will be created for queries which time out.
     #  Run a query which will not respond, and check that the timeout works
-    if (!RUBY_PLATFORM=~/darwin/)
+    if (RUBY_PLATFORM !~ /darwin/)
       start=stop=0
       retry_times = 3
       retry_delay=1


### PR DESCRIPTION
Prior to this commit we were seeing a deprecation warning when running
tests locally on Ruby 2.7.1 (e.g. https://travis-ci.org/github/alexdalitz/dnsruby/jobs/715103346).

```
test/tc_resolver.rb:174: warning: deprecated Object#=~ is called on FalseClass; it always returns nil
```

`!RUBY_PLATFORM=~/darwin/` was always returning `nil` because
`!RUBY_PLATFORM` returned `false`, then we called `false =~ /darwin/`.

Co-authored-by: Adam Hess <hparker@github.com>