### PR TITLE
Address Ruby 2.8 #untaint deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,8 @@ rvm:
   - 2.6.6
   - 2.5.8
   - 2.7.1
+  - ruby-head
 
+matrix:
+  allow_failures:
+    - rvm: ruby-head

--- a/lib/dnsruby/config.rb
+++ b/lib/dnsruby/config.rb
@@ -321,9 +321,11 @@ module Dnsruby
         f.each {|line|
           line.sub!(/[#;].*/, '')
           keyword, *args = line.split(/\s+/)
-          args.each { |arg|
-            arg.untaint
-          }
+            if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.8")
+              args.each { |arg|
+                arg.untaint
+              }
+            end
           next unless keyword
           case keyword
           when 'port'

--- a/lib/dnsruby/hosts.rb
+++ b/lib/dnsruby/hosts.rb
@@ -57,15 +57,19 @@ module Dnsruby
                 line.sub!(/#.*/, '')
                 addr, hostname, *aliases = line.split(/\s+/)
                 next unless addr
-                addr.untaint
-                hostname.untaint
+                if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.8")
+                  addr.untaint
+                  hostname.untaint
+                end
                 @addr2name[addr] = [] unless @addr2name.include? addr
                 @addr2name[addr] << hostname
                 @addr2name[addr] += aliases
                 @name2addr[hostname] = [] unless @name2addr.include? hostname
                 @name2addr[hostname] << addr
                 aliases.each {|n|
-                  n.untaint
+                  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.8")
+                    n.untaint
+                  end
                   @name2addr[n] = [] unless @name2addr.include? n
                   @name2addr[n] << addr
                 }


### PR DESCRIPTION
Prior to this commit we were seeing errors when calling the deprecated
Object#untaint method on Ruby 2.8. The method is a no-op on Ruby 2.8.

```rb
dnsruby/config.rb:325: warning: Object#untaint is deprecated and will be removed in Ruby 3.2
```

We probably could remove untainting for older Ruby versions as well, but
it felt safer to preserve the current behavior in case someone is still
relying on it.

To see this change in action, we added ruby-head to the travis matrix,
but do not require those tests to pass for the build as a whole to pass.

See https://bugs.ruby-lang.org/issues/16131 for details on the
deprecation.