### PR TITLE
Clear Ruby warnings

### DIFF
--- a/lib/dnsruby/DNS.rb
+++ b/lib/dnsruby/DNS.rb
@@ -290,7 +290,7 @@ module Dnsruby
         msg.do_caching = do_caching
         @resolver.do_validation = false
         @resolver.send_async(msg, q)
-        id, ret, exception = q.pop
+        _id, ret, exception = q.pop
         if (exception == nil && ret && ret.rcode == RCode.NOERROR)
           return ret, ret.question[0].qname
         end

--- a/lib/dnsruby/config.rb
+++ b/lib/dnsruby/config.rb
@@ -85,13 +85,10 @@ module Dnsruby
     def initialize()
       @mutex = Mutex.new
       @configured = false
-      #       parse_config
     end
     #  Reset the config to default values
     def Config.reset
-      c = Config.new
       @configured = false
-      #       c.parse_config
     end
 
     def parse_config(config_info=nil) #:nodoc: all
@@ -207,13 +204,13 @@ module Dnsruby
         if (String ===n)
           #  Make sure we can make a Name or an address from it
           begin
-            a = IPv4.create(n)
+            IPv4.create(n)
           rescue ArgumentError
             begin
-              a = IPv6.create(n)
+              IPv6.create(n)
             rescue ArgumentError
               begin
-                a = Name.create(n)
+                Name.create(n)
               rescue ArgumentError
                 raise ArgumentError.new("Can't interpret #{n} as IPv4, IPv6 or Name")
               end

--- a/lib/dnsruby/message/encoder.rb
+++ b/lib/dnsruby/message/encoder.rb
@@ -17,7 +17,7 @@ class MessageEncoder #:nodoc: all
   def put_pack(template, *d)
     begin
       @data << d.pack(template)
-    rescue Encoding::CompatibilityError => e
+    rescue Encoding::CompatibilityError
       raise Dnsruby::EncodeError.new("IDN support currently requires punycode string")
     end
   end
@@ -35,7 +35,7 @@ class MessageEncoder #:nodoc: all
     begin
       self.put_pack("C", d.length)
       @data << d
-    rescue Encoding::CompatibilityError => e
+    rescue Encoding::CompatibilityError
       raise Dnsruby::EncodeError.new("IDN support currently requires punycode string")
     end
   end

--- a/lib/dnsruby/message/header.rb
+++ b/lib/dnsruby/message/header.rb
@@ -31,9 +31,6 @@ class Header
   #  and is allowed to set the bit by policy.)
   attr_accessor :ad
 
-  #  The query response flag
-  attr_accessor :qr
-
   #  Recursion available flag
   attr_accessor :ra
 

--- a/lib/dnsruby/name.rb
+++ b/lib/dnsruby/name.rb
@@ -259,7 +259,7 @@ module Dnsruby
     #  in: dName a string with a domain name in presentation format (1035
     #  sect 5.1)
     #  out: an array of labels in wire format.
-    def self.name2encodedlabels (dName) #:nodoc: all
+    def self.name2encodedlabels(dName) #:nodoc: all
       #  Check for "\" in the name  : If there, then decode properly - otherwise, cheat and split on "."
       if (dName.index("\\"))
         names=[]

--- a/lib/dnsruby/packet_sender.rb
+++ b/lib/dnsruby/packet_sender.rb
@@ -204,26 +204,22 @@ module Dnsruby
       @tcp_pipelining_max_queries = :infinite
       @use_counts = {}
 
-      if (arg==nil)
-        #  Get default config
-        config = Config.new
-        #         @server = config.nameserver[0]
-      elsif (arg.kind_of? String)
-        @server=arg
-      elsif (arg.kind_of? Name)
-        @server=arg
-      elsif (arg.kind_of? Hash)
+      if arg.nil?
+      elsif arg.kind_of? String
+        @server = arg
+      elsif arg.kind_of? Name
+        @server = arg
+      elsif arg.kind_of? Hash
         arg.keys.each do |attr|
           begin
-            if (((attr.to_s == "src_address")||(attr.to_s == "src_address6")) &&
-                ((arg[attr] == nil) || (arg[attr] == "")))
+            if ((attr.to_s == "src_address" || attr.to_s == "src_address6") &&
+                (arg[attr] == nil || arg[attr] == ""))
             else
-              send(attr.to_s+"=", arg[attr])
+              send(attr.to_s + "=", arg[attr])
             end
           rescue Exception => e
             Dnsruby.log.error { "PacketSender : Argument #{attr}, #{arg[attr]} not valid : #{e}\n" }
           end
-          #         end
         end
       end
       # Check server is IP
@@ -235,12 +231,12 @@ module Dnsruby
 
     def check_ipv6
       begin
-        i = IPv4.create(@server)
+        IPv4.create(@server)
         #         @src_address = '0.0.0.0'
         @ipv6=false
       rescue Exception
         begin
-          i = IPv6.create(@server)
+          IPv6.create(@server)
           #           @src_address6 = '::'
           @ipv6=true
         rescue Exception

--- a/lib/dnsruby/recursor.rb
+++ b/lib/dnsruby/recursor.rb
@@ -264,7 +264,7 @@ module Dnsruby
               }
             }
             (hints.length * 2).times {
-              id, result, error = q.pop
+              _id, result, _error = q.pop
               if (result)
                 result.answer.each {|rr|
                   TheLog.debug(";; NS address: " + rr.inspect+"\n")
@@ -638,7 +638,7 @@ module Dnsruby
         packet = resolver.send_message(query)
         #  @TODO@ Now prune unrelated RRSets (RFC 5452 section 6)
         prune_rrsets_to_rfc5452(packet, known_zone)
-      rescue ResolvTimeout, IOError => e
+      rescue ResolvTimeout, IOError
         #             TheLog.debug(";; nameserver #{levelns.to_s} didn't respond")
         #             next
         TheLog.debug("No response!")

--- a/lib/dnsruby/resolver.rb
+++ b/lib/dnsruby/resolver.rb
@@ -130,7 +130,9 @@ module Dnsruby
     #  The current Config
     attr_reader :config
 
-    #  Does this Resolver cache answers, and attempt to retrieve answer from the cache?
+    #  Defines whether we will cache responses, or pass every request to the
+    #  upstream resolver.  This is only really useful when querying authoritative
+    #  servers (as the upstream recursive resolver is likely to cache)
     attr_reader :do_caching
 
     #  The array of SingleResolvers used for sending query messages
@@ -172,11 +174,6 @@ module Dnsruby
     #  Message object to be passed in, which is already configured to the callers
     #  requirements.
     attr_accessor :do_validation
-
-    #  Defines whether we will cache responses, or pass every request to the
-    #  upstream resolver.  This is only really useful when querying authoritative
-    #  servers (as the upstream recursive resolver is likely to cache)
-    attr_accessor :do_caching
 
     #  --
     #  @TODO@ add load_balance? i.e. Target nameservers in a random, rather than pre-determined, order?

--- a/lib/dnsruby/resource/CAA.rb
+++ b/lib/dnsruby/resource/CAA.rb
@@ -26,7 +26,7 @@ module Dnsruby
       # The value for the property_tag
       attr_accessor :property_value
       # The value for the flag
-      attr_accessor :flag
+      attr_writer :flag
 
       def from_hash(hash) #:nodoc: all
         @property_tag = hash[:property_tag]

--- a/lib/dnsruby/resource/NSEC3PARAM.rb
+++ b/lib/dnsruby/resource/NSEC3PARAM.rb
@@ -85,7 +85,7 @@ module Dnsruby
       #       end
       # 
       def from_data(data) #:nodoc: all
-        hash_alg, flags, iterations, salt_length, salt = data
+        hash_alg, flags, iterations, _salt_length, salt = data
         self.hash_alg=(hash_alg)
         self.flags=(flags)
         self.iterations=(iterations)

--- a/lib/dnsruby/resource/TLSA.rb
+++ b/lib/dnsruby/resource/TLSA.rb
@@ -33,8 +33,8 @@ module Dnsruby
         # 255 Private use
         attr_accessor :matching_type
         # sec 2.1.4
-        attr_accessor :data
-        attr_accessor :databin
+        attr_reader :data
+        attr_reader :databin
 
         def verify
           raise ArgumentError, "usage with invalid value: #{@usage}" if @usage < 0 || @usage > 255
@@ -71,7 +71,7 @@ module Dnsruby
           if @matching_type == 0 && @selector == 0 && @databin
             begin
               cert = OpenSSL::X509::Certificate.new(@databin)
-            rescue => e
+            rescue
               raise ArgumentError, 'data is invalid cert '
             end
           end

--- a/lib/dnsruby/single_verifier.rb
+++ b/lib/dnsruby/single_verifier.rb
@@ -462,7 +462,6 @@ module Dnsruby
     def check_no_wildcard_expansion(msg) # :nodoc:
       #  @TODO@ Do this for NSEC3 records!!!
       proven_no_wildcards = false
-      name = msg.question()[0].qname
       [msg.authority.rrsets('NSEC'), msg.authority.rrsets('NSEC3')].each {|nsec_rrsets|
         nsec_rrsets.each {|nsecs|
           nsecs.rrs.each {|nsec|
@@ -1329,8 +1328,7 @@ module Dnsruby
             msg.security_level = Message::SecurityLevel.SECURE
             return true
           end
-        rescue VerifyError => e
-          #           print "Verify failed : #{e}\n"
+        rescue VerifyError
         end
       end
       if (error)

--- a/lib/dnsruby/zone_reader.rb
+++ b/lib/dnsruby/zone_reader.rb
@@ -68,7 +68,7 @@ module Dnsruby
             end
             zone.push(rr)
           end
-        rescue Exception => e
+        rescue Exception
           raise ParseException.new("Error reading line #{io.lineno} of #{io.inspect} : [#{line}]")
         end
       end
@@ -303,7 +303,7 @@ module Dnsruby
         (split.length - 2).times {|i| line += "#{split[i+2]} "}
         line += "\n"
         split = line.split
-      rescue Error => e
+      rescue Error
       end
 
       #  Add the type so we can load the zone one RRSet at a time.

--- a/lib/dnsruby/zone_transfer.rb
+++ b/lib/dnsruby/zone_transfer.rb
@@ -244,7 +244,6 @@ module Dnsruby
     end
 
     def parseRR(rec) #:nodoc: all
-      name = rec.name
       type = rec.type
       delta = Delta.new
 

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -1,3 +1,9 @@
+$VERBOSE = true
+
+if Warning.respond_to?(:[]=)
+  Warning[:deprecated] = true
+end
+
 if ENV['RUN_EXTRA_TASK'] == 'TRUE'
   require 'coveralls'
   Coveralls.wear!

--- a/test/tc_resolver.rb
+++ b/test/tc_resolver.rb
@@ -132,7 +132,7 @@ class TestResolver < Minitest::Test
     r = Resolver.new
     q=Queue.new
     r.send_async(m,q,q)
-    id,ret, error=q.pop
+    _id, ret, _error=q.pop
     assert(ret.kind_of?(Message))
     no_pointer=true
     ret.each_answer do |answer|
@@ -185,14 +185,14 @@ class TestResolver < Minitest::Test
         res.retry_times=retry_times
         res.retry_delay=retry_delay
         start=Time.now
-        m = res.send_message(Message.new("a.t.dnsruby.validation-test-servers.nominet.org.uk", Types.A))
+        res.send_message(Message.new("a.t.dnsruby.validation-test-servers.nominet.org.uk", Types.A))
         fail
       rescue ResolvTimeout
         stop=Time.now
         time = stop-start
         assert(time <= expected * 1.3 && time >= expected * 0.9, "Wrong time take, expected #{expected}, took #{time}")
       end
-  end
+    end
   end
 
   def test_packet_timeout
@@ -209,7 +209,7 @@ class TestResolver < Minitest::Test
         #  Work out what time should be, then time it to check
         expected = query_timeout
         start=Time.now
-        m = res.send_message(Message.new("a.t.dnsruby.validation-test-servers.nominet.org.uk", Types.A))
+        res.send_message(Message.new("a.t.dnsruby.validation-test-servers.nominet.org.uk", Types.A))
         fail
       rescue Dnsruby::ResolvTimeout
         stop=Time.now
@@ -227,7 +227,7 @@ class TestResolver < Minitest::Test
       res.query_timeout=expected
       q = Queue.new
       start = Time.now
-      m = res.send_async(Message.new("a.t.dnsruby.validation-test-servers.nominet.org.uk", Types.A), q, q)
+      res.send_async(Message.new("a.t.dnsruby.validation-test-servers.nominet.org.uk", Types.A), q, q)
       id,ret,err = q.pop
       stop = Time.now
       assert(id=q)
@@ -382,19 +382,19 @@ class TestRawQuery < Minitest::Test
           resolver.query("google.com", "MX")
           begin
             resolver.query("googlöe.com", "MX") 
-          rescue Dnsruby::ResolvError => e
+          rescue Dnsruby::ResolvError
             # fine
           end
           resolver.query("google.com", "MX")
           resolver.query("google.com", "MX")
           begin
             resolver.query("googlöe.com", "MX")
-          rescue Dnsruby::ResolvError => e
+          rescue Dnsruby::ResolvError
             # fine
           end
           begin
             resolver.query("googlöe.com", "MX") 
-          rescue Dnsruby::ResolvError => e
+          rescue Dnsruby::ResolvError
             # fine
           end
 #          Dnsruby::Cache.delete("googlöe.com", "MX")

--- a/test/tc_tcp.rb
+++ b/test/tc_tcp.rb
@@ -142,14 +142,14 @@ class TestTcp < Minitest::Test
       ans = HackMessage.decode(received_query)
       ans.wipe_additional
       100.times {|i|
-      ans.add_additional(Dnsruby::RR.create("example.com 3600 IN A 1.2.3.#{i}"))
+        ans.add_additional(Dnsruby::RR.create("example.com 3600 IN A 1.2.3.#{i}"))
       }
       ans.header.arcount = 110
       ans.header.tc = true
       socket.send(ans.encode,0)
     }
 
-        server_thread = Thread.new {
+    _server_thread = Thread.new {
       ts = TCPServer.new(port)
       t = ts.accept
       packet = t.recvfrom(2)[0]

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -1,5 +1,3 @@
-require_relative 'spec_helper'
-
 # Use this in tests in the tests directory with:
 # require_relative 'test_utils'
 # include TestUtils


### PR DESCRIPTION
DNSRuby generates tons of unused variable and other ruby warnings.

That's a problem for applications and libraries depending on it and trying to catch issues on CI/test with these warnings.

This PR clear most warnings, there's still a bunch in the test suite, but I believe it's a good start.