### PR TITLE
Fix compatibility with Ruby 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
+        ruby: [ '2.5', '2.6', '2.7', '3.0', 'ruby-head' ]
     name: Ruby ${{ matrix.ruby }} tests
     steps:
       - uses: actions/checkout@v2

--- a/dnsruby.gemspec
+++ b/dnsruby.gemspec
@@ -47,5 +47,5 @@ DNSSEC NSEC3 support.'
   end
 
   s.add_runtime_dependency 'simpleidn', '~> 0.1'
+  s.add_runtime_dependency 'net-ftp'
 end
-


### PR DESCRIPTION
Ruby 3.1 remove a few default gems, `net-ftp` is among them. So for Ruby 3.1 compatibility it is important to add `net-ftp` as a dependency.