### PR TITLE
Remove dependency on net-ftp

### DIFF
--- a/dnsruby.gemspec
+++ b/dnsruby.gemspec
@@ -47,5 +47,4 @@ DNSSEC NSEC3 support.'
   end
 
   s.add_runtime_dependency 'simpleidn', '~> 0.1'
-  s.add_runtime_dependency 'net-ftp'
 end

--- a/lib/dnsruby/dnssec.rb
+++ b/lib/dnsruby/dnssec.rb
@@ -14,7 +14,6 @@
 # limitations under the License.
 # ++
 require 'digest/sha2'
-require 'net/ftp'
 require 'dnsruby/key_cache'
 require 'dnsruby/single_verifier'
 module Dnsruby


### PR DESCRIPTION
So turns out `Net::FTP` isn't used by dnsruby since a good decade, the `require` was just left there. Sorry I should have checked before adding the dependency.

It was introduced in 58c05cd2596d1daad11b565d22cf187a9babddce (2009) to download IANA tar archive, but removed in f9b99a11ff83ebdbe44dae273931184415f90b5a (2010).

But no big deal.