### PR TITLE
Remove require to titlecased Digest

### DIFF
--- a/lib/dnsruby/resource/DS.rb
+++ b/lib/dnsruby/resource/DS.rb
@@ -14,11 +14,8 @@
 # limitations under the License.
 # ++
 require 'base64'
-begin
-require 'Digest/sha2'
-rescue LoadError
-  require 'digest/sha2'
-end
+require 'digest/sha2'
+
 module Dnsruby
   class RR
     # RFC4034, section 4


### PR DESCRIPTION
There are a few requires to "digest" in this library, but this is the only one attempting the require using title case.

Some users on case-insensitive filesystems were reported strange results because of this (which I didn't totally figure out). I think it's best to just require the right library name from the right place.