### PR TITLE
Add issuemail CAA record support

### DIFF
--- a/lib/dnsruby/resource/CAA.rb
+++ b/lib/dnsruby/resource/CAA.rb
@@ -43,7 +43,7 @@ module Dnsruby
       end
 
       def from_string(input) #:nodoc: all
-        matches = (/(\d+) (issuewild|issue|iodef|contactemail|contactphone) "(.+)"$/).match(input)
+        matches = (/(\d+) (issuewild|issuemail|issue|iodef|contactemail|contactphone) "(.+)"$/).match(input)
         @flag = matches[1]
         @property_tag = matches[2]
         @property_value = matches[3]

--- a/test/tc_caa.rb
+++ b/test/tc_caa.rb
@@ -25,6 +25,7 @@ class TestCAA < Minitest::Test
     {'foo.com. IN CAA 0 issue "ca.example.net"' => [0, 'issue', 'ca.example.net'],
      'foo.com. IN CAA 1 issue "ca.example.net"' => [1, 'issue', 'ca.example.net'],
      'foo.com. IN CAA 0 issuewild "ca.example.net"' => [0, 'issuewild', 'ca.example.net'],
+     'foo.com. IN CAA 0 issuemail "ca.example.net"' => [0, 'issuemail', 'ca.example.net'],
      'foo.com. IN CAA 0 iodef "mailto:security@example.com"' => [0, 'iodef', 'mailto:security@example.com'],
      'foo.com. IN CAA 0 issue "ca.example.net; account=230123"' => [0, 'issue', 'ca.example.net; account=230123']
     }.each do |text, data|


### PR DESCRIPTION
When a hostname has an `issuemail` record, DNSRuby throws an error:
```
dig +short CAA esmt.org
0 issuemail "pki.dfn.de"
0 issuewild "sectigo.com"
0 issue "sectigo.com"
0 issue "pki.dfn.de"
0 issuemail "sectigo.com"
0 issue "letsencrypt.org"
```

```
resolver.query('esmt.org', 'CAA')
NoMethodError: undefined method `[]' for nil:NilClass
from /usr/local/lib/ruby/gems/3.0.0/gems/dnsruby-1.61.5/lib/dnsruby/resource/CAA.rb:47:in `from_string'
```

The issuemail record is a relatively new RFC: https://datatracker.ietf.org/doc/rfc9495/

I think I did this right, lmk what can be improved/changed!
