### PR TITLE
Include the DNS record received when unable to parse a CAA record

### DIFF
--- a/lib/dnsruby/resource/CAA.rb
+++ b/lib/dnsruby/resource/CAA.rb
@@ -45,7 +45,7 @@ module Dnsruby
       def from_string(input) #:nodoc: all
         matches = (/(\d+) (issuewild|issuemail|issue|iodef|contactemail|contactphone) "(.+)"$/).match(input)
         if matches.nil?
-          raise DecodeError.new("Cannot parse record")
+          raise DecodeError.new("Cannot parse record: #{input[0...1000]}")
         end
         @flag = matches[1]
         @property_tag = matches[2]


### PR DESCRIPTION
This helps with debugging to see the record that DnsRuby sees. It also helps if the DNS record changed between when the exception was raised and when you view the logs. This happens a lot with our infrastructure 🙂 LMK if this is sane/useful!