### PR TITLE
allow parsing case insensitive property tags for CAA records

### DIFF
--- a/lib/dnsruby/resource/CAA.rb
+++ b/lib/dnsruby/resource/CAA.rb
@@ -43,7 +43,7 @@ module Dnsruby
       end
 
       def from_string(input) #:nodoc: all
-        matches = (/(\d+) (issuewild|issuemail|issue|iodef|contactemail|contactphone) "(.+)"$/).match(input)
+        matches = (/(\d+) (issuewild|issuemail|issue|iodef|contactemail|contactphone) "(.+)"$/i).match(input)
         if matches.nil?
           raise DecodeError.new("Cannot parse record: #{input[0...1000]}")
         end


### PR DESCRIPTION
This will parse case insensitive property tags for CAA records per the RFCs.

https://github.com/alexdalitz/dnsruby/issues/201