### PR TITLE
Gem and Ruby 3.4 updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '3.1', '3.2', '3.3' ] # , 'ruby-head' ]
+        ruby: [ '3.2', '3.3', '3.4' ] # , 'ruby-head' ]
         rubyopt: ['']
         include:
-          - ruby: '3.3'
+          - ruby: '3.4'
             rubyopt: "--enable-frozen-string-literal --debug-frozen-string-literal"
 
     name: Ruby ${{ matrix.ruby }} tests

--- a/dnsruby.gemspec
+++ b/dnsruby.gemspec
@@ -36,18 +36,14 @@ DNSSEC NSEC3 support.'
   }
 
   s.add_development_dependency 'rake', '>= 13.0.6'
-  s.add_development_dependency 'minitest', '~> 5.18.0'
+  s.add_development_dependency 'minitest', '~> 5.25'
   s.add_development_dependency 'rubydns', '>= 2.0.2'
   s.add_development_dependency 'nio4r', '>= 2.5.8'
   s.add_development_dependency 'minitest-display', '>= 0.3.1'
-  s.add_development_dependency('yard', '>= 0.9')
-  # s.add_development_dependency('io-event', '>=1.1.7')
+  s.add_development_dependency 'yard', '>= 0.9'
+  s.add_development_dependency 'coveralls', '~> 0.8.23'
 
-  if RUBY_VERSION >= "1.9.3"
-    s.add_development_dependency 'coveralls', '~> 0.8.23'
-  end
-
-  s.add_runtime_dependency 'base64', '~> 0.2.0'
-  s.add_runtime_dependency 'logger', '~> 1.6.5'
+  s.add_runtime_dependency 'base64', '~> 0.2'
+  s.add_runtime_dependency 'logger', '~> 1.6'
   s.add_runtime_dependency 'simpleidn', '~> 0.2.1'
 end

--- a/lib/dnsruby/resource/DNSKEY.rb
+++ b/lib/dnsruby/resource/DNSKEY.rb
@@ -383,7 +383,7 @@ module Dnsruby
           ]
         )
 
-        pkey = OpenSSL::PKey::DSA.new(asn1.to_der)
+        OpenSSL::PKey::DSA.new(asn1.to_der)
       end
 
       # RFC6605, section 4

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -26,7 +26,7 @@ require 'minitest'
 require 'minitest/autorun'
 require 'minitest/display'
 
-MiniTest::Display.options = {
+Minitest::Display.options = {
   suite_names: true,
   color: true,
   print: {


### PR DESCRIPTION
* Allow newer base64, logger
* Use newer minitest for Ruby 3.4 compat
* Update CI for Ruby 3.4
* Fix Ruby warning
