### PR TITLE
Automatically add EDNS OPT RR when udp_size >512, even if dnssec=false

### DIFF
--- a/lib/dnsruby/resolver.rb
+++ b/lib/dnsruby/resolver.rb
@@ -888,6 +888,13 @@ module Dnsruby
         return
       end
 
+      # According to RFC 6891, a UDP payload size >512 bytes requires an
+      # EDNS OPT RR in the message.
+      if @parent.udp_size > 512 && !msg.get_opt
+        TheLog.debug("Automatically adding EDNS OPT RR for udp_size=#{ @parent.udp_size }")
+        msg.add_additional(Dnsruby::RR::OPT.new(@parent.udp_size))
+      end
+
       begin
         msg.encode
       rescue EncodeError => err

--- a/lib/dnsruby/resolver.rb
+++ b/lib/dnsruby/resolver.rb
@@ -299,15 +299,17 @@ module Dnsruby
     #  is sent (TSIG signatures will be applied if configured on the Resolver).
     #  Retries are handled as the Resolver is configured to do.
     #  Incoming responses to the query are not cached or validated (although TCP
-    #  fallback will be performed if the TC bit is set and the (Single)Resolver has
-    #  ignore_truncation set to false).
-    #  Note that the Message is left untouched - this means that no OPT records are
-    #  added, even if the UDP transport for the server is specified at more than 512
-    #  bytes. If it is desired to use EDNS for this packet, then you should call
-    #  the Dnsruby::PacketSender#prepare_for_dnssec(msg), or
-    #  Dnsruby::PacketSender#add_opt_rr(msg)
-    #  The return value from this method is the [response, error] tuple. Either of
-    #  these values may be nil - it is up to the client to check.
+    #  fallback will be performed if the TC bit is set and the (Single)Resolver
+    #  has ignore_truncation set to false).
+    #  Note that the Message may be modified before sending: if the configured
+    #  udp_size is >512 bytes, DNSSEC is not set, and no OPT record is already
+    #  present, then an OPT record will be added automatically to support EDNS
+    #  per RFC 6891.
+    #  If it is desired to customize the OPT record or use EDNS in other cases,
+    #  then you should call the Dnsruby::PacketSender#prepare_for_dnssec(msg),
+    #  or Dnsruby::PacketSender#add_opt_rr(msg).
+    #  The return value from this method is the [response, error] tuple. Either
+    #  of these values may be nil - it is up to the client to check.
     #
     #  example :
     #

--- a/test/tc_resolver.rb
+++ b/test/tc_resolver.rb
@@ -285,37 +285,72 @@ class TestResolver < Minitest::Test
     #  @TODO@ TEST THE Resolver::EventType interface!
   end
 
+  def capture_sent_message(res, domain, pre_opt=nil)
+    q = Queue.new
+    res.send_async(Dnsruby::Message.new("test.invalid"), q)
+    q.pop
+    resolver_ruby = res.instance_variable_get("@resolver_ruby")
+    class << resolver_ruby
+      attr_accessor :message
+      alias_method :original_send_async, :send_async
+      def send_async(msg, client_queue, client_query_id=nil)
+        @message = msg
+        original_send_async(msg, client_queue, client_query_id)
+      end
+    end
+    msg = Dnsruby::Message.new(domain)
+    msg.add_additional(pre_opt) if pre_opt
+    res.send_async(msg, q)
+    _id, _response, _error = q.pop
+    resolver_ruby.message
+  end
+
   def test_custom_udp_size
-    [false, true].each do |dnssec_value|
-      res = Dnsruby::Resolver.new(:udp_size => 1232, :dnssec => dnssec_value)
-      q = Queue.new
-      # Call send_async once to initialize @resolver_ruby
-      res.send_async(Dnsruby::Message.new("test.invalid"), q)
-      q.pop
-      resolver_ruby = res.instance_variable_get("@resolver_ruby")
-      class << resolver_ruby
-        attr_accessor :message
-        alias_method :original_send_async, :send_async
-        def send_async(msg, client_queue, client_query_id=nil)
-          @message = msg
-          original_send_async(msg, client_queue, client_query_id)
+    [false, true].each do |dnssec_setting|
+      [512, 513].each do |udp_size_setting|
+        res = Dnsruby::Resolver.new(:udp_size => udp_size_setting, :dnssec => dnssec_setting)
+        sent_msg = capture_sent_message(res, "example.com")
+
+        # The OPT RR is only present if the udp_size is > 512
+        opt = sent_msg.get_opt
+        if dnssec_setting
+          # DNSSEC overrides udp_size to 4096
+          assert(opt)
+          assert_equal(4096, opt.klass.code)
+        else
+          if udp_size_setting <= 512
+            assert_nil(opt)
+          else
+            assert(opt)
+            assert_equal(udp_size_setting, opt.klass.code)
+          end
+        end
+        if opt
+          assert_equal(0, opt.version)
+          assert_equal(0, opt.flags)
         end
       end
-      res.send_async(Dnsruby::Message.new("example.com"), q)
-      _id, _response, _error = q.pop
-      opt = resolver_ruby.message.get_opt
-      assert(opt)
-      if dnssec_value
-        assert_equal(4096, opt.klass.code) # DNSSEC overrides to 4096
-      else
-        assert_equal(1232, opt.klass.code)
+    end
+  end
+
+  def test_no_duplicate_opt_when_pre_existing
+    [false, true].each do |dnssec_setting|
+      [512, 513].each do |udp_size_setting|
+        res = Dnsruby::Resolver.new(:udp_size => udp_size_setting, :dnssec => dnssec_setting)
+        pre_size = dnssec_setting ? 4096 : 1024
+        pre_opt = Dnsruby::RR::OPT.new(pre_size)
+        sent_msg = capture_sent_message(res, "example.com", pre_opt)
+
+        opt = sent_msg.get_opt
+        assert(opt)
+        assert_equal(1, sent_msg.additional.length) # No duplicate added
+        assert_equal(pre_size, opt.klass.code) # Original payload size unchanged
+        assert_equal(0, opt.version)
+        assert_equal(0, opt.flags) # Flags unchanged (code doesn't modify existing OPT)
       end
-      assert_equal(0, opt.version)
-      assert_equal(0, opt.flags)
     end
   end
 end
-
 
 # Tests to see that query_raw handles send_plain_message's return values correctly.
 class TestRawQuery < Minitest::Test

--- a/test/tc_single_resolver.rb
+++ b/test/tc_single_resolver.rb
@@ -128,7 +128,7 @@ class TestSingleResolver < Minitest::Test
   end
 
   def test_queries
-    res = SingleResolver.new("127.0.0.1")
+    res = SingleResolver.new
 
     Rrs.each do |data|
       packet=nil

--- a/test/tc_single_resolver.rb
+++ b/test/tc_single_resolver.rb
@@ -128,7 +128,7 @@ class TestSingleResolver < Minitest::Test
   end
 
   def test_queries
-    res = SingleResolver.new
+    res = SingleResolver.new("127.0.0.1")
 
     Rrs.each do |data|
       packet=nil


### PR DESCRIPTION
This PR adds automatic support for EDNS (Extension Mechanisms for DNS) in Dnsruby when the udp_size configuration is set >512 bytes, even if dnssec is false. Previously, queries with larger UDP sizes wouldn't include the required OPT resource record, causing truncation and TCP fallbacks for responses exceeding 512 bytes (e.g., large TXT or SPF records). This change checks for udp_size > 512 during message preparation and adds a basic EDNS0 OPT RR if none exists, following RFC 6891 for improved compatibility with modern DNS servers.