### PR TITLE
Remove id from query_hash when retrying over TCP due to UDP truncation

### DIFF
--- a/lib/dnsruby/select_thread.rb
+++ b/lib/dnsruby/select_thread.rb
@@ -372,12 +372,12 @@ module Dnsruby
     end
 
     def remove_id(id)
-
       @@mutex.synchronize do
         remove_id_from_mutex_synchronized_block(id)
       end
     end
 
+    # THIS MUST BE CALLED FROM INSIDE A @@mutex SYNCHRONISED BLOCK!
     def remove_id_from_mutex_synchronized_block(id)
       socket = @@query_hash[id].socket
       @@timeouts.delete(id)


### PR DESCRIPTION
Related to issue https://github.com/alexdalitz/dnsruby/issues/209