### PR TITLE
fix(caa): add support for issuevmc

### DIFF
--- a/lib/dnsruby/resource/CAA.rb
+++ b/lib/dnsruby/resource/CAA.rb
@@ -21,7 +21,7 @@ module Dnsruby
       ClassValue = nil #:nodoc: all
       TypeValue= Types::CAA #:nodoc: all
 
-      # The property tag for the record (issue|issuewild|iodef)
+      # The property tag for the record (issue|issuewild|issuemail|issuevmc|iodef|contactemail|contactphone)
       attr_accessor :property_tag
       # The value for the property_tag
       attr_accessor :property_value
@@ -43,7 +43,7 @@ module Dnsruby
       end
 
       def from_string(input) #:nodoc: all
-        matches = (/(\d+) (issuewild|issuemail|issue|iodef|contactemail|contactphone) "(.+)"$/i).match(input)
+        matches = (/(\d+) (issuewild|issuemail|issuevmc|issue|iodef|contactemail|contactphone) "(.+)"$/i).match(input)
         if matches.nil?
           raise DecodeError.new("Cannot parse record: #{input[0...1000]}")
         end

--- a/test/tc_caa.rb
+++ b/test/tc_caa.rb
@@ -26,6 +26,7 @@ class TestCAA < Minitest::Test
      'foo.com. IN CAA 1 issue "ca.example.net"' => [1, 'issue', 'ca.example.net'],
      'foo.com. IN CAA 0 issuewild "ca.example.net"' => [0, 'issuewild', 'ca.example.net'],
      'foo.com. IN CAA 0 issuemail "ca.example.net"' => [0, 'issuemail', 'ca.example.net'],
+     'foo.com. IN CAA 0 issuevmc "ca.example.net"' => [0, 'issuevmc', 'ca.example.net'],
      'foo.com. IN CAA 0 iodef "mailto:security@example.com"' => [0, 'iodef', 'mailto:security@example.com'],
      'foo.com. IN CAA 0 issue "ca.example.net; account=230123"' => [0, 'issue', 'ca.example.net; account=230123']
     }.each do |text, data|


### PR DESCRIPTION
The CAA record `issuevmc` tag isn't currently supported:
https://www.iana.org/assignments/pkix-parameters/pkix-parameters.xhtml#caa-properties