### PR TITLE
Fix leaking sockets

### DIFF
--- a/lib/dnsruby/select_thread.rb
+++ b/lib/dnsruby/select_thread.rb
@@ -393,6 +393,9 @@ module Dnsruby
       if !persistent?(socket) || max_attained?(socket)
         @@sockets.delete(socket)
         @@socket_hash.delete(socket)
+        @@socket_remaining_queries.delete(socket)
+        @@socket_is_persistent.delete(socket)
+        @@tcp_buffers.delete(socket)
         Dnsruby.log.debug("Closing socket #{socket}")
         socket.close rescue nil
       end


### PR DESCRIPTION
Dnsruby is leaking sockets (both TCP and UDP). The sockets are closed, but `@socket` is used as a key in several hashes in `SelectThread` and those keys and their values are global and kept forever. This PR ensures those key/value pairs are cleaned up.

This has been tested in production here and shows a marked improvement in overall memory consumption. Sockets are being GC'd properly now.

A count of in-memory objects (via `sigdump` gem). 
```
# Before
97,841: UDPSocket
4: Socket    (TCP sockets)

# After
6: UDPSocket
0: Socket
```
