### PR TITLE
Fix WKS record protocol field encoding.

### DIFF
--- a/lib/dnsruby/resource/IN.rb
+++ b/lib/dnsruby/resource/IN.rb
@@ -87,13 +87,13 @@ module Dnsruby
 
         def encode_rdata(msg, canonical=false) #:nodoc: all
           msg.put_bytes(@address.address)
-          msg.put_pack("n", @protocol)
+          msg.put_pack("C", @protocol)
           msg.put_bytes(@bitmap)
         end
 
         def self.decode_rdata(msg) #:nodoc: all
           address = IPv4.new(msg.get_bytes(4))
-          protocol, = msg.get_unpack("n")
+          protocol, = msg.get_unpack("C")
           bitmap = msg.get_bytes
           return self.new(address, protocol, bitmap)
         end


### PR DESCRIPTION
Fix WKS record protocol field encoding and decoding size according to RFC 1035 Section 3.4.2 where PROTOCOL is an 8 bit.
I spotted the errror using  Dnsruby::ZoneTransfer where i got the error
```
Dnsruby::MessageDecoder#assert_buffer_position_valid': requested position of 1871 must be     
  between 0 and buffer size (1870). (Dnsruby::DecodeError) 
```

The patch just change the pack format from "n" to "C" in `lib/dnsruby/resource/IN.rb`